### PR TITLE
Switch to standalone cobra-cli dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build-deps: ## Install the build dependencies
 dev-deps: ## Install the dev dependencies
 	@echo " > Installing dev deps"
 	$(GO_BIN) install golang.org/x/tools/...@latest
-	$(GO_BIN) install github.com/spf13/cobra/cobra
+	$(GO_BIN) install github.com/spf13/cobra-cli@latest
 	$(GO_BIN) get -d golang.org/x/tools/cmd/cover
 	$(GO_BIN) get -d github.com/caarlos0/svu@v1.4.1
 


### PR DESCRIPTION
Switches to use the extracted cobra-cli command since it is being removed from the github.com/spf13/cobra module (xref https://github.com/spf13/cobra/issues/1597)