### PR TITLE
Fix permissions and mounts on WSL2/linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN buildDeps='libfuse3-dev bzip2 libbz2-dev libz-dev cmake build-essential git 
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+ENV IPSW_IN_DOCKER=1
 
 COPY --from=builder /bin/ipsw /bin/ipsw
 

--- a/pkg/dyld/extract.go
+++ b/pkg/dyld/extract.go
@@ -73,8 +73,16 @@ func Extract(ipsw, destPath string, arches []string) error {
 			config.Prefix = filepath.Join(config.MountPoint, config.CacheFolder) + "/"
 			config.Glob = config.CacheFolder + "dyld_shared_cache_*"
 		} else {
-			os.MkdirAll(filepath.Join("/data", destPath), os.ModePerm)
-			config.MountPoint = "/mnt"
+			os.MkdirAll(destPath, os.ModePerm)
+
+			// Create temporary mount point
+			config.MountPoint = dmgs[0] + "_temp_mount"
+			if err := os.Mkdir(config.MountPoint, os.ModePerm); err != nil {
+				return errors.Wrapf(err, "Unable to create temporary mount point.")
+			} else {
+				defer os.RemoveAll(config.MountPoint)
+			}
+
 			config.Prefix = filepath.Join(config.MountPoint, config.CacheFolder) + "/"
 			config.Glob = "root/" + config.CacheFolder + "dyld_shared_cache_*"
 		}

--- a/pkg/dyld/extract.go
+++ b/pkg/dyld/extract.go
@@ -73,14 +73,18 @@ func Extract(ipsw, destPath string, arches []string) error {
 			config.Prefix = filepath.Join(config.MountPoint, config.CacheFolder) + "/"
 			config.Glob = config.CacheFolder + "dyld_shared_cache_*"
 		} else {
-			os.MkdirAll(destPath, os.ModePerm)
-
-			// Create temporary mount point
-			config.MountPoint = dmgs[0] + "_temp_mount"
-			if err := os.Mkdir(config.MountPoint, os.ModePerm); err != nil {
-				return errors.Wrapf(err, "Unable to create temporary mount point.")
+			if _, ok := os.LookupEnv("IPSW_IN_DOCKER"); ok {
+				os.MkdirAll(filepath.Join("/data", destPath), os.ModePerm)
+				config.MountPoint = "/mnt"
 			} else {
-				defer os.RemoveAll(config.MountPoint)
+				// Create temporary mount point
+				os.MkdirAll(destPath, os.ModePerm)
+				config.MountPoint = dmgs[0] + "_temp_mount"
+				if err := os.Mkdir(config.MountPoint, os.ModePerm); err != nil {
+					return errors.Wrapf(err, "Unable to create temporary mount point.")
+				} else {
+					defer os.RemoveAll(config.MountPoint)
+				}
 			}
 
 			config.Prefix = filepath.Join(config.MountPoint, config.CacheFolder) + "/"


### PR DESCRIPTION
I'm running on WSL2, and after installing `ipsw` with the deb file, I ran into some issues regarding `apfs-fuse` and output folders.

`apfs-fuse` requires root when using `/mnt` as the mount point. By creating a temporary directory in a location that the user likely owns, it is able to mount without root. Alternatively, creating a directory in `/tmp` could also work.

I also removed the prepending of `/data` when it is preparing the output directory. While this allows the output to be anywhere, it will break docker invocations that assumes the output path is in `/data`. Maybe we can specify in the docs, that for docker, the output paths must begin at `/data`, or maybe we can look for `/.dockerenv` and automatically prepend it.

Let me know what you think, thanks!