### PR TITLE
fix: do not use recursive directories when downloading several IPSW

### DIFF
--- a/cmd/ipsw/cmd/download/download_ipsw.go
+++ b/cmd/ipsw/cmd/download/download_ipsw.go
@@ -312,8 +312,7 @@ var ipswCmd = &cobra.Command{
 					if err != nil {
 						log.Errorf("failed to get folder from remote ipsw metadata: %v", err)
 					}
-					destPath = filepath.Join(destPath, folder)
-					if err := utils.RemoteUnzip(zr.File, dlRE, destPath, flat); err != nil {
+					if err := utils.RemoteUnzip(zr.File, dlRE, filepath.Join(destPath, folder), flat); err != nil {
 						return fmt.Errorf("failed to download pattern matching files from remote ipsw: %v", err)
 					}
 				}


### PR DESCRIPTION
When downloading several IPSW files, the output directory structure was recursive, like so:

![Screenshot from 2022-09-20 16-47-00](https://user-images.githubusercontent.com/8809698/191314329-7863e62e-63df-42de-aca9-ec4e6ba9faeb.png)

Now it looks like this:

![image](https://user-images.githubusercontent.com/8809698/191313909-a0ed3f24-0d90-4d04-9909-41d8a1dc489a.png)
