### PR TITLE
fix: return correct kernel collection path on x86_64 machines

### DIFF
--- a/internal/utils/macos.go
+++ b/internal/utils/macos.go
@@ -361,10 +361,19 @@ func GetBuildInfo() (*BuildInfo, error) {
 
 func GetKernelCollectionPath() (string, error) {
 	if runtime.GOOS == "darwin" {
-		cmd := exec.Command("sysctl", "-n", "kern.bootobjectspath")
+		defaultKcPath := "/System/Library/KernelCollections/BootKernelExtensions.kc"
+
+		cmd := exec.Command("uname", "-m")
 		out, err := cmd.CombinedOutput()
+
+		if err == nil && strings.Contains(string(out), "x86_64") {
+			return defaultKcPath, nil
+		}
+
+		cmd = exec.Command("sysctl", "-n", "kern.bootobjectspath")
+		out, err = cmd.CombinedOutput()
 		if err != nil {
-			return "/System/Library/KernelCollections/BootKernelExtensions.kc", nil
+			return defaultKcPath, nil
 		}
 		return filepath.Join("/System/Volumes/Preboot", strings.TrimSpace(string(out)), "System/Library/Caches/com.apple.kernelcaches/kernelcache"), nil
 	}


### PR DESCRIPTION
On Intel Ventura 13.2, `GetKernelCollectionPath` attempts to return a kernel collection from `/System/Volumes/Preboot` (like on an Apple Silicon machine), because `sysctl -n bootobjectspath` does not throw an error.

If the machine is an `x86_64` machine, we should return `/System/Library/KernelCollections/BootKernelExtensions.kc`. Otherwise (if we are on an Apple Silicon device), defer to the previous behavior (try to return the kernelcache in `Preboot`, or return `/System/Library/KernelCollections/BootKernelExtensions.kc` if we cannot find the `Preboot` path with `sysctl`).

Desired behavior (`x86_64`, `22D49`):

```
# ipsw kernel kmutil inspect -x --filter "Skywalk"
  • Parsing KernelManagement kernelcache
  ...
```

Observed behavior (`x86_64`, `22D49`):

```
# ipsw kernel kmutil inspect -x --filter "Skywalk"
  ⨯ file /System/Volumes/Preboot/.../com.apple.kernelcaches/kernelcache does not exist
```