### PR TITLE
fix: guard the base64 repair/parse from invalid pallas response

### DIFF
--- a/internal/download/ota.go
+++ b/internal/download/ota.go
@@ -496,6 +496,10 @@ func (o *Ota) GetPallasOTAs() ([]types.Asset, error) {
 
 		// repair/parse base64 response data
 		parts := strings.Split(string(body), ".")
+		if len(parts) < 2 {
+			log.Errorf("failed to base64 decode pallas response: cannot split response body \"%s\" ", string(body))
+			continue
+		}
 		b64Str := parts[1]
 		b64Str = strings.ReplaceAll(b64Str, "-", "+")
 		b64Str = strings.ReplaceAll(b64Str, "_", "/")


### PR DESCRIPTION
I saw the following panic in our logs today:

```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/blacktop/ipsw/internal/download.(*Ota).GetPallasOTAs(0xc000106820)
	github.com/blacktop/ipsw/internal/download/ota.go:499 +0xe37
github.com/blacktop/ipsw/cmd/ipsw/cmd/download.glob..func9(0x204d820?, {0x4a14aa?, 0x4?, 0x4?})
	github.com/blacktop/ipsw/cmd/ipsw/cmd/download/download_ota.go:271 +0x13df
github.com/spf13/cobra.(*Command).execute(0x204d820, {0xc0003ecec0, 0x4, 0x4})
	github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0x204a740)
	github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.7.0/command.go:992
github.com/blacktop/ipsw/cmd/ipsw/cmd.Execute()
	github.com/blacktop/ipsw/cmd/ipsw/cmd/root.go:64 +0x25
main.main()
	github.com/blacktop/ipsw/cmd/ipsw/main.go:27 +0x17
```

when invoking `ipsw download ota --platform ios --urls --json`. This is probably due to an intermittent issue with the "pallas" endpoints. But since the `parts` access isn't guarded `ipsw` crashes instead of logging an error. This PR adds a simple guard and logs an error with the response-body.