### PR TITLE
dyld_search.go: check for symReStr emptiness to avoid command parsing failing

### DIFF
--- a/cmd/ipsw/cmd/dyld/dyld_search.go
+++ b/cmd/ipsw/cmd/dyld/dyld_search.go
@@ -92,7 +92,7 @@ var dyldSearchCmd = &cobra.Command{
 		ivarReStr := viper.GetString("dyld.search.ivar")
 		symReStr := viper.GetString("dyld.search.sym")
 		// verify flags
-		if loadCmdReStr == "" && protocolReStr == "" && classReStr == "" && categoryReStr == "" && selectorReStr == "" && ivarReStr == "" {
+		if loadCmdReStr == "" && protocolReStr == "" && classReStr == "" && categoryReStr == "" && selectorReStr == "" && ivarReStr == "" && symReStr == "" {
 			return fmt.Errorf("must specify a search criteria via one of the flags")
 		}
 


### PR DESCRIPTION
Otherwise you get: `⨯ must specify a search criteria via one of the flags`

Still even with this fix, I don't get any output from:
`> ipsw dsc search sys/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e --sym '.*ShowTouches.*'` on `iPhone12,8_17.0.2_21A351_Restore.ipsw`. `--sym 'ShowTouches'` gives nada as well.

String search finds hits:
```
> ipsw dsc str sys/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e -p 'ShowTouches'
   • Searching for strings...
0x18b3ce103: ShowTouches                UIKitCore
0x18b3ce10f: ShowTouchesForAllProcesses UIKitCore
0x1db733f88: ShowTouches                UIKitCore
0x1db733fa8: ShowTouchesForAllProcesses UIKitCore
0x21c15aa52: setShowTouches:            OpusFoundation
```

And it is apparently even in `.symbols`:
```
ug -r ShowTouches app fs sys
Binary file sys/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e.01 matches

Binary file sys/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e.03 matches

Binary file sys/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e.45 matches

Binary file sys/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e.symbols matches
```

Also nada results using `iPhone12,8_14.0_18A373_Restore.ipsw` and `iPhone12,8_15.0_19A346_Restore.ipsw`.

Any ideas? I'm going throw these 17.0.2, 15.0, and 14.0 DSCs in the latest Ghidra and see what it thinks.