### PR TITLE
Make contributing to docs easier

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -44,7 +44,9 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/blacktop/ipsw/tree/master/www/",
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/blacktop/ipsw/master/editor/www/docs/${docPath}`
+          },
         },
         gtag: {
           trackingID: "G-6PLDXGZBEK",


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/blacktop/ipsw/master/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb