### PR TITLE
bugfix: extract --dmg flag is not working

### DIFF
--- a/cmd/ipsw/cmd/extract.go
+++ b/cmd/ipsw/cmd/extract.go
@@ -103,7 +103,7 @@ var extractCmd = &cobra.Command{
 		}
 
 		// validate args
-		if !viper.GetBool("extract.kernel") && !viper.GetBool("extract.dyld") && !viper.GetBool("extract.dmg") &&
+		if !viper.GetBool("extract.kernel") && !viper.GetBool("extract.dyld") && !viper.IsSet("extract.dmg") &&
 			!viper.GetBool("extract.dtree") && !viper.GetBool("extract.iboot") && !viper.GetBool("extract.sep") &&
 			!viper.GetBool("extract.sptm") && !viper.GetBool("extract.kbag") && !viper.GetBool("extract.sys-ver") &&
 			len(viper.GetString("extract.pattern")) == 0 {


### PR DESCRIPTION
For string value, GetBool returns false even the option is supplied, making this option unusable