### PR TITLE
fix: prevent panic in Info.GetFolder()

### DIFF
--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -426,6 +426,10 @@ func (i *Info) GetCPU(board string) string {
 
 // GetFolder returns a folder name for all the devices included in an IPSW
 func (i *Info) GetFolder(device ...string) (string, error) {
+	if i.Plists.BuildManifest == nil {
+		return "", fmt.Errorf("no BuildManifest.plist found")
+	}
+
 	var dev string
 	if len(device) > 0 && len(device[0]) > 0 {
 		dev = device[0]


### PR DESCRIPTION
I recently encountered an older OTA that did not have a `BuildManifest.plist`, which caused a `SIGSEGV` panic. You checked the `BuildManifest` existence in other `Info` functions, too, so I added the guard at the top since all happy paths of `GetFolder()` seem to require it.