### PR TITLE
fix: ld doesn't recognize tbd files that don't end with three dots

### DIFF
--- a/pkg/tbd/template.go
+++ b/pkg/tbd/template.go
@@ -17,4 +17,5 @@ exports:
 {{- if .ObjcIvars }}    
     objc-ivars:      [ {{ StringsJoin .ObjcIvars ",\n                       " }} ]
 {{- end }}
+...
 `


### PR DESCRIPTION
`ld` doesn't seem to recognize TBD files that don't end with `...`. This patch adds the missing three dots to the TBD template to avoid linking errors.

```console
% "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld" -demangle -lto_library /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libLTO.dylib -dynamic -dylib -arch x86_64 -platform_version macos 10.13.0 10.13.0 -syslibroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk -o /Users/user/Documents/MyTool/.build/x86_64-apple-macosx/debug/libMASDownloadMetadata.dylib -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/lib/swift -L/Users/user/Documents/MyTool/.build/x86_64-apple-macosx/debug -L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib /Users/user/Documents/MyTool/.build/x86_64-apple-macosx/debug/MASDownloadMetadataLib.build/MASDownloadMetadata.m.o -rpath /usr/lib/swift -framework StoreFoundation -install_name @rpath/libMASDownloadMetadata.dylib -rpath @loader_path -lSystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/15.0.0/lib/darwin/libclang_rt.osx.a -F/Users/user/Documents/MyTool/.build/x86_64-apple-macosx/debug -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -v 
@(#)PROGRAM:ld PROJECT:ld-1053.12
BUILD 15:44:24 Feb  3 2024
configured to support archs: armv6 armv7 armv7s arm64 arm64e arm64_32 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em
will use ld-classic for: armv6 armv7 armv7s arm64_32 i386 armv6m armv7k armv7m armv7em
LTO support using: LLVM version 15.0.0 (static support for 29, runtime is 29)
TAPI support using: Apple TAPI version 15.0.0 (tapi-1500.3.2.2)
Library search paths:
	/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx
	/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/lib/swift
	/Users/user/Documents/MyTool/.build/x86_64-apple-macosx/debug
	/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib
	/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/lib
	/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/lib/swift
Framework search paths:
	/Users/user/Documents/MyTool/.build/x86_64-apple-macosx/debug
	/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks
	/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/System/Library/Frameworks
ld: unknown file type in '/Users/user/Documents/MyTool/.build/x86_64-apple-macosx/debug/StoreFoundation.framework/StoreFoundation.tbd'
```

Related: https://forums.swift.org/t/how-to-link-to-objc-framework-from-the-dyld-shared-cache-in-package-swift/68788/18