### PR TITLE
feat: add missing i386 and x86_64h targets to tbd

### DIFF
--- a/pkg/tbd/tbd.go
+++ b/pkg/tbd/tbd.go
@@ -84,6 +84,8 @@ func NewTBD(image *dyld.CacheImage, reexports []string, private bool) (*TBD, err
 
 	return &TBD{
 		Targets: []string{
+			"i386-macos",
+			"i386-maccatalyst",
 			"x86_64-macos",
 			"x86_64-maccatalyst",
 			"x86_64h-macos",

--- a/pkg/tbd/tbd.go
+++ b/pkg/tbd/tbd.go
@@ -86,6 +86,8 @@ func NewTBD(image *dyld.CacheImage, reexports []string, private bool) (*TBD, err
 		Targets: []string{
 			"x86_64-macos",
 			"x86_64-maccatalyst",
+			"x86_64h-macos",
+			"x86_64h-maccatalyst",
 			"arm64-macos",
 			"arm64-maccatalyst",
 			"arm64e-macos",


### PR DESCRIPTION
This patch adds the missing `i386-macos`, `i386-maccatalyst`, `x86_64h-macos`, and `x86_64h-maccatalyst` targets to TBD generation.

```console
% head /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libSystem.B.tbd 
--- !tapi-tbd
tbd-version:     4
targets:         [ i386-macos, i386-maccatalyst, x86_64-macos, x86_64-maccatalyst, 
                   arm64-macos, arm64-maccatalyst, arm64e-macos, arm64e-maccatalyst ]
install-name:    '/usr/lib/libSystem.B.dylib'
current-version: 1345.100.2
reexported-libraries:
  - targets:         [ i386-macos, i386-maccatalyst, x86_64-macos, x86_64-maccatalyst, 
                       arm64-macos, arm64-maccatalyst, arm64e-macos, arm64e-maccatalyst ]
    libraries:       [ '/usr/lib/system/libsystem_kernel.dylib', '/usr/lib/system/libsystem_platform.dylib', 
```

```console
% head /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation.tbd 
--- !tapi-tbd
tbd-version:     4
targets:         [ x86_64-macos, x86_64-maccatalyst, x86_64h-macos, x86_64h-maccatalyst, 
                   arm64-macos, arm64-maccatalyst, arm64e-macos, arm64e-maccatalyst ]
install-name:    '/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation'
current-version: 2420
compatibility-version: 150
reexported-libraries:
  - targets:         [ x86_64-macos, x86_64-maccatalyst, x86_64h-macos, x86_64h-maccatalyst, 
                       arm64-macos, arm64-maccatalyst, arm64e-macos, arm64e-maccatalyst ]
```