### PR TITLE
fix: check if superclass has local header

### DIFF
--- a/internal/commands/macho/objc.go
+++ b/internal/commands/macho/objc.go
@@ -890,8 +890,12 @@ func (o *ObjC) processForwardDeclarations(m *macho.File) (map[string]Imports, er
 	}
 
 	for _, class := range classes {
-		imp := Imports{}
-		imp.Imports = append(imp.Imports, class.SuperClass+".h")
+		var imp Imports
+		if slices.Contains(classNames, class.SuperClass) {
+			imp.Locals = append(imp.Locals, class.SuperClass+".h")
+		} else {
+			imp.Classes = append(imp.Classes, class.SuperClass)
+		}
 		for _, prot := range class.Protocols {
 			if slices.Contains(protoNames, prot.Name) {
 				imp.Locals = append(imp.Locals, prot.Name+"-Protocol.h")


### PR DESCRIPTION
Only import header for superclass if it exists.

Before:
```objc
@import Foundation;

#include "NSWindowController.h"
#include "ISAuthenticationContext.h"
#include "ISDialog.h"
#include "ISStoreClient.h"

@class NSButton, NSImageView, NSProgressIndicator, NSTextField, NSWindow;

@interface ISSignInPrompt : NSWindowController {
```

After:
```objc
@import Foundation;

#include "ISAuthenticationContext.h"
#include "ISDialog.h"
#include "ISStoreClient.h"

@class NSButton, NSImageView, NSProgressIndicator, NSTextField, NSWindow, NSWindowController;

@interface ISSignInPrompt : NSWindowController {
```