### PR TITLE
docs: Update outdated commands and options

### DIFF
--- a/www/docs/guides/debugserver.md
+++ b/www/docs/guides/debugserver.md
@@ -14,7 +14,7 @@ description: Prep jailbroken device for remote debugging.
 ```
 
 ```bash
-❯ ipsw debugserver --force
+❯ ipsw ssh debugserver --force
 
    • Connecting to root@localhost:2222
 ? Select the DeveloperDiskImage you want to extract the debugserver from: 14.1/DeveloperDiskImage.dmg

--- a/www/docs/guides/download.md
+++ b/www/docs/guides/download.md
@@ -172,7 +172,7 @@ Download **latest** `macOS` IPSWs
 To just output the latest iOS version
 
 ```bash
-❯ ipsw download ipsw --show-latest
+❯ ipsw download ipsw --show-latest-version
 
 15.1
 ```
@@ -446,7 +446,7 @@ Your Developer Portal credentials and session are stored securely in your Keycha
 :::
 
 :::caution note
-The `--vault-password` flag is the encryption password for the **file** based vaults that will be placed encrypted in the `~/.ipsw` directory. This is **NOT** for your Developer Portal credentials.  
+The `--vault-password` flag is the encryption password for the **file** based vaults that will be placed encrypted in the `~/.ipsw` directory. This is **NOT** for your Developer Portal credentials.
 
 This is when ran on an OS that does not have a native Keychain, Credential Manager or Keyring etc.
 :::

--- a/www/docs/guides/shsh.md
+++ b/www/docs/guides/shsh.md
@@ -14,7 +14,7 @@ description: Dumping shsh blobs allows you to downgrade iOS later.
 ```
 
 ```bash
-❯ ipsw shsh
+❯ ipsw ssh shsh
 
    • Connecting to root@localhost:2222
       • Parsing shsh


### PR DESCRIPTION
Update (some) outdated commands and options in the documentation, as they've moved into a parent command or have been renamed

In summary

- `ipsw shsh` -> `ipsw ssh shsh`
- `ipsw debugserver` -> `ipsw ssh debugserver`
- `ipsw download ipsw`: `--show-latest` -> `--show-latest-version` and `--show-latest-build` (though, in context, the guides only mention how to see the latest iOS version, not build)