### PR TITLE
docs: Update install instructions for MacPorts

### DIFF
--- a/www/docs/getting-started/installation.md
+++ b/www/docs/getting-started/installation.md
@@ -36,6 +36,12 @@ brew install blacktop/tap/ipsw-frida
 ## Via [MacPorts](https://www.macports.org)
 
 ```bash
+sudo port install ipsw
+```
+
+### Install development version
+
+```bash
 git clone https://github.com/blacktop/ports ~/.config/macports/blacktop
 ```
 


### PR DESCRIPTION
MacPorts hosts `ipsw` on their default repository now, so move new users over to their version. Other options remain available as `ipsw` on MacPorts may not always be up-to-date due to a review process required on each update.