### PR TITLE
fix: cast `macho.Load` to `*macho.LoadDylib`

### DIFF
--- a/cmd/ipsw/cmd/macho/macho_patch.go
+++ b/cmd/ipsw/cmd/macho/macho_patch.go
@@ -248,7 +248,7 @@ func patchMacho(m *macho.File, machoPath, action, loadCommand string, args []str
 				return fmt.Errorf("failed to find %s in %s", loadCommand, machoPath)
 			}
 			for _, lc := range lcs {
-				if lc.(*macho.Dylib).Name == args[3] {
+				if lc.(*macho.LoadDylib).Name == args[3] {
 					if err := m.RemoveLoad(lc); err != nil {
 						return fmt.Errorf("failed to remove load command: %v", err)
 					}


### PR DESCRIPTION
This patch addresses a panic while running `ipsw macho patch rm`.

```console
% ipsw macho patch rm ./CommerceKit LC_LOAD_DYLIB /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
? You are about to overwrite ./CommerceKit. Continue? Yes
   • Deleting load command LC_LOAD_DYLIB from ./CommerceKit
panic: interface conversion: macho.Load is *macho.LoadDylib, not *macho.Dylib

goroutine 1 [running]:
github.com/blacktop/ipsw/cmd/ipsw/cmd/macho.patchMacho(0xc0008e0000, {0x7ff7b3784a70, 0x2a}, {0x7ff7b3784a6d, 0x2}, {0x7ff7b3784a9b, 0xd}, {0xc00035a580, 0x4, 0x4})
    github.com/blacktop/ipsw/cmd/ipsw/cmd/macho/macho_patch.go:251 +0x410d
github.com/blacktop/ipsw/cmd/ipsw/cmd/macho.init.func13(0x10eb6ab80?, {0xc00035a580, 0x4, 0x4})
    github.com/blacktop/ipsw/cmd/ipsw/cmd/macho/macho_patch.go:622 +0x4f0
github.com/spf13/cobra.(*Command).execute(0x10eb6ab80, {0xc00035a500, 0x4, 0x4})
    github.com/spf13/cobra@v1.8.0/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0x10eb46100)
    github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
    github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/blacktop/ipsw/cmd/ipsw/cmd.Execute()
    github.com/blacktop/ipsw/cmd/ipsw/cmd/root.go:67 +0x1a
main.main()
    github.com/blacktop/ipsw/cmd/ipsw/main.go:27 +0xf
```