### PR TITLE
fix: fix slice init length

### DIFF
--- a/cmd/ipsw/cmd/download/download.go
+++ b/cmd/ipsw/cmd/download/download.go
@@ -178,7 +178,7 @@ func filterIPSWs(cmd *cobra.Command, macos bool) ([]download.IPSW, error) {
 	}
 
 	unique := make(map[string]bool, len(filteredIPSWs))
-	uniqueIPSWs := make([]download.IPSW, len(unique))
+	uniqueIPSWs := make([]download.IPSW, 0, len(unique))
 	for _, i := range filteredIPSWs {
 		if len(i.URL) != 0 {
 			if !unique[i.URL] {

--- a/internal/download/itunes.go
+++ b/internal/download/itunes.go
@@ -64,7 +64,7 @@ type ITunesVersionMaster struct {
 
 // UniqueBuilds returns a slice with Builds with unique FirmwareURLs
 func UniqueBuilds(b []Build) []Build {
-	unique := make(map[string]bool, len(b))
+	unique := make(map[string]bool, 0, len(b))
 	bs := make([]Build, len(unique))
 	for _, elem := range b {
 		if len(elem.URL) != 0 {

--- a/internal/download/ota.go
+++ b/internal/download/ota.go
@@ -662,7 +662,7 @@ func (o *Ota) GetPallasOTAs() ([]types.Asset, error) {
 
 func uniqueOTAs(otas []types.Asset) []types.Asset {
 	unique := make(map[string]bool, len(otas))
-	os := make([]types.Asset, len(unique))
+	os := make([]types.Asset, 0, len(unique))
 	for _, elem := range otas {
 		if len(elem.BaseURL+elem.RelativePath) != 0 {
 			if !unique[elem.BaseURL+elem.RelativePath] {

--- a/pkg/usb/apps/installation.go
+++ b/pkg/usb/apps/installation.go
@@ -144,7 +144,7 @@ func (c *Client) InstalledApps() ([]AppInfo, error) {
 		return nil, err
 	}
 
-	result := make([]AppInfo, len(apps))
+	result := make([]AppInfo, 0, len(apps))
 
 	var app AppInfo
 	if err := mapstructure.Decode(apps, &app); err != nil {


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW