### PR TITLE
Fix llm-related key names for `macho disass`

### DIFF
--- a/cmd/ipsw/cmd/macho/macho_disass.go
+++ b/cmd/ipsw/cmd/macho/macho_disass.go
@@ -310,17 +310,17 @@ var machoDisassCmd = &cobra.Command{
 								return fmt.Errorf("failed to get prompt format string and syntax highlight lexer: %v", err)
 							}
 							llm, err := ai.NewAI(context.Background(), &ai.Config{
-								Provider:    viper.GetString("dyld.disass.llm"),
+								Provider:    viper.GetString("macho.disass.llm"),
 								Prompt:      fmt.Sprintf(promptFmt, asm),
-								Model:       viper.GetString("dyld.disass.dec-model"),
-								Temperature: viper.GetFloat64("dyld.disass.dec-temp"),
-								TopP:        viper.GetFloat64("dyld.disass.dec-top-p"),
+								Model:       viper.GetString("macho.disass.dec-model"),
+								Temperature: viper.GetFloat64("macho.disass.dec-temp"),
+								TopP:        viper.GetFloat64("macho.disass.dec-top-p"),
 								Stream:      true,
 							})
 							if err != nil {
 								return fmt.Errorf("failed to create llm client: %v", err)
 							}
-							if !viper.IsSet("dyld.disass.dec-model") {
+							if !viper.IsSet("macho.disass.dec-model") {
 								var choice string
 								prompt := &survey.Select{
 									Message:  "Select model to use:",
@@ -466,17 +466,17 @@ var machoDisassCmd = &cobra.Command{
 							return fmt.Errorf("failed to get prompt format string and syntax highlight lexer: %v", err)
 						}
 						llm, err := ai.NewAI(context.Background(), &ai.Config{
-							Provider:    viper.GetString("dyld.disass.llm"),
+							Provider:    viper.GetString("macho.disass.llm"),
 							Prompt:      fmt.Sprintf(promptFmt, asm),
-							Model:       viper.GetString("dyld.disass.dec-model"),
-							Temperature: viper.GetFloat64("dyld.disass.dec-temp"),
-							TopP:        viper.GetFloat64("dyld.disass.dec-top-p"),
+							Model:       viper.GetString("macho.disass.dec-model"),
+							Temperature: viper.GetFloat64("macho.disass.dec-temp"),
+							TopP:        viper.GetFloat64("macho.disass.dec-top-p"),
 							Stream:      true,
 						})
 						if err != nil {
 							return fmt.Errorf("failed to create llm client: %v", err)
 						}
-						if !viper.IsSet("dyld.disass.dec-model") {
+						if !viper.IsSet("macho.disass.dec-model") {
 							var choice string
 							prompt := &survey.Select{
 								Message:  "Select model to use:",


### PR DESCRIPTION
When using `macho disass` command with new LLM features, like

```ipsw macho disass --dec --dec-model "GPT-4.1 (Preview)" --llm "copilot" --dec-lang "Swift" --demangle ./passd```

I've noticed that I've been asked to choose a model each time regardless of setting the `--dec-model` argument or not.


After taking a look inside, I've noticed that most of the keys in that module started with `macho.disass`, but the LLM-related keys started with `dyld.disass`, just like in `dyld_disass` module, which made me think that those keys should have been updated.

Doing that fixed the issue for me.