### PR TITLE
feat: add `--dec-retries` and `--dec-retry-backoff` arguments

### DIFF
--- a/internal/commands/disass/disass.go
+++ b/internal/commands/disass/disass.go
@@ -31,6 +31,8 @@ type Config struct {
 	Verbose      bool
 	Color        bool
 	Theme        string
+	MaxRetries   int
+	RetryBackoff time.Duration
 }
 
 func Decompile(asm string, cfg *Config) (string, error) {
@@ -48,6 +50,8 @@ func Decompile(asm string, cfg *Config) (string, error) {
 		Stream:       cfg.Stream,
 		DisableCache: cfg.DisableCache,
 		Verbose:      cfg.Verbose,
+		MaxRetries:   cfg.MaxRetries,
+		RetryBackoff: cfg.RetryBackoff,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create llm client: %v", err)


### PR DESCRIPTION
This PR adds two new arguments to `dyld disass` and `macho disass`:
* `--dec-retries`, which allows configuring how many times to try calling the API again on failure (default 0 - no retries, behaves as before);
* `--dec-retry-backoff`, configures the amount of time to wait before querying the API again upon failure, which helps to avoid rate limit issues. Default value is 30 seconds.

Those parameters enable users to initiate a set-and-forget decompilation process for a big binary (while piping the output into a file, for instance).

On my set-up, I've been able to run the decompilation for two 3+ MB dylibs in a single run over the course of a day, with the retry logic saving me a couple of times in the process to continue after rate-limit errors from the API.
