### PR TITLE
Reset resume property on downloader before determining if file can and should be resumed

### DIFF
--- a/internal/download/downloader.go
+++ b/internal/download/downloader.go
@@ -155,6 +155,7 @@ func (d *Download) Do() error {
 		}
 	}
 
+	d.resume = false
 	if d.canResume {
 		if f, err := os.Stat(d.DestName + ".download"); !os.IsNotExist(err) {
 			// don't try to download files being downloaded elsewhere


### PR DESCRIPTION
When downloading multiple files, the downloader will try to resume a non-existing file if it previously resumed another file that did exist. The reason for this is that the `resume` property did not get reset between downloads.

Example: 
1. ipsw wants to download 1.ipsw and 2.ipsw
2. 1.ipsw.download exists, ipsw resumes
3. 1.ipsw download completes
4. `resume` is now true
5. 2.ipsw.download does not exist, but `resume` remains true
6. Download fails with `failed to download IPSW: cannot open 2.ipsw.download: open 2.ipsw.download: no such file or directory`