### PR TITLE
fix: use proper platform name in word copy for version count

### DIFF
--- a/www/src/pages/entitlements.tsx
+++ b/www/src/pages/entitlements.tsx
@@ -739,7 +739,7 @@ export default function Entitlements() {
                                                 </h3>
                                                 {globalMetadata && (
                                                     <p className="text-sm" style={{ color: 'var(--ifm-color-content-secondary)' }}>
-                                                        {globalMetadata.uniqueVersions > 1 && `${globalMetadata.uniqueVersions} iOS versions • `}
+                                                        {globalMetadata.uniqueVersions > 1 && `${globalMetadata.uniqueVersions} ${selectedPlatform} versions • `}
                                                         {globalMetadata.uniqueFiles} unique files
                                                     </p>
                                                 )}


### PR DESCRIPTION
It's been a bit since I've coded in React, so this might cause render issues with their dependency model. Regardless, I hope my intention with this is clear. When searching for macOS binaries with a given entitlement, the word copy still mentions "iOS" (as it is hard-coded to). This makes the word copy actually use the currently-searched-for platform name.