### PR TITLE
feat: implement mount without blocking

### DIFF
--- a/www/docs/cli/ipsw/mount.md
+++ b/www/docs/cli/ipsw/mount.md
@@ -20,6 +20,9 @@ ipsw mount [fs|sys|app|exc|rdisk] IPSW [flags]
 # Mount the filesystem DMG from an IPSW
 $ ipsw mount fs iPhone15,2_16.5_20F66_Restore.ipsw
 
+# Mount the filesystem without blocking or prompting the user to unmount the DMG
+$ ipsw mount fs --detach iPhone15,2_16.5_20F66_Restore.ipsw
+
 # Mount the system DMG with a specific decryption key
 $ ipsw mount sys iPhone.ipsw --key "a1b2c3d4e5f6..."
 


### PR DESCRIPTION
For use cases that would benefit from being about to use the ipsw CLI to mount disk images without blocking. The use of this flag will still mount the disk image after decrypting, but exits cleanly immediately after.