### PR TITLE
fix(color): respect TTY detection for ANSI color output

### DIFF
--- a/cmd/ipsw/cmd/appstore/appstore_profile_info.go
+++ b/cmd/ipsw/cmd/appstore/appstore_profile_info.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/blacktop/go-plist"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/fullsailor/pkcs7"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func init() {
@@ -73,7 +73,7 @@ var ASProfileInfoCmd = &cobra.Command{
 			return fmt.Errorf("failed to marshal json: %v", err)
 		}
 
-		if viper.GetBool("color") && !viper.GetBool("no-color") {
+		if colors.Active() {
 			if err := quick.Highlight(os.Stdout, string(jsonData)+"\n", "json", "terminal256", "nord"); err != nil {
 				return fmt.Errorf("failed to highlight json: %v", err)
 			}

--- a/cmd/ipsw/cmd/class_dump.go
+++ b/cmd/ipsw/cmd/class_dump.go
@@ -31,6 +31,7 @@ import (
 	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho"
+	"github.com/blacktop/ipsw/internal/colors"
 	mcmd "github.com/blacktop/ipsw/internal/commands/macho"
 	"github.com/blacktop/ipsw/internal/magic"
 	"github.com/blacktop/ipsw/pkg/dyld"
@@ -157,7 +158,7 @@ var classDumpCmd = &cobra.Command{
 			// Generic:     viper.GetBool("class-dump.generic"),
 			Demangle:    demangleOpt,
 			IpswVersion: fmt.Sprintf("Version: %s, BuildCommit: %s", strings.TrimSpace(AppVersion), strings.TrimSpace(AppBuildCommit)),
-			Color:       viper.GetBool("color") && !viper.GetBool("no-color"),
+			Color:       colors.Active(),
 			Theme:       viper.GetString("class-dump.theme"),
 			Output:      viper.GetString("class-dump.output"),
 		}

--- a/cmd/ipsw/cmd/download/download_appledb.go
+++ b/cmd/ipsw/cmd/download/download_appledb.go
@@ -35,6 +35,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/commands/extract"
 	"github.com/blacktop/ipsw/internal/download"
 	"github.com/blacktop/ipsw/internal/utils"
@@ -323,7 +324,7 @@ var downloadAppledbCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				if viper.GetBool("color") && !viper.GetBool("no-color") {
+				if colors.Active() {
 					if err := quick.Highlight(os.Stdout, string(b)+"\n", "json", "terminal256", "nord"); err != nil {
 						return fmt.Errorf("failed to highlight json: %v", err)
 					}
@@ -367,7 +368,7 @@ var downloadAppledbCmd = &cobra.Command{
 				return fmt.Errorf("failed to marshal json: %v", err)
 			}
 
-			if viper.GetBool("color") && !viper.GetBool("no-color") {
+			if colors.Active() {
 				if err := quick.Highlight(os.Stdout, string(jsonData)+"\n", "json", "terminal256", "nord"); err != nil {
 					return fmt.Errorf("failed to highlight json: %v", err)
 				}

--- a/cmd/ipsw/cmd/download/download_ota.go
+++ b/cmd/ipsw/cmd/download/download_ota.go
@@ -35,11 +35,11 @@ import (
 	"github.com/apex/log"
 	"github.com/blacktop/ipsw/internal/commands/extract"
 	"github.com/blacktop/ipsw/internal/download"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/dyld"
 	"github.com/blacktop/ipsw/pkg/ota/types"
 	"github.com/dustin/go-humanize"
-	"github.com/fatih/color"
 	semver "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -252,9 +252,9 @@ var downloadOtaCmd = &cobra.Command{
 				for _, dl := range dvt.Downloadables {
 					fmt.Printf("%-40s %s=%s\t%s=%s\n",
 						dl.Name,
-						color.New(color.Bold, color.FgHiBlue).Sprint("build"),
+						colors.BoldHiBlue().Sprint("build"),
 						dl.SimulatorVersion.BuildUpdate,
-						color.New(color.Bold, color.FgHiBlue).Sprint("size"),
+						colors.BoldHiBlue().Sprint("size"),
 						humanize.Bytes(uint64(dl.FileSize)),
 					)
 				}

--- a/cmd/ipsw/cmd/dyld/dyld.go
+++ b/cmd/ipsw/cmd/dyld/dyld.go
@@ -24,20 +24,20 @@ package dyld
 import (
 	"path/filepath"
 
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/pkg/dyld"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
-var symAddrColor = color.New(color.Faint).SprintfFunc()
-var symTypeColor = color.New(color.Faint, color.FgCyan).SprintfFunc()
-var symLibColor = color.New(color.Faint, color.FgMagenta).SprintfFunc()
-var symNameColor = color.New(color.Bold).SprintFunc()
+var symAddrColor = colors.Faint().SprintfFunc()
+var symTypeColor = colors.FaintCyan().SprintfFunc()
+var symLibColor = colors.FaintMagenta().SprintfFunc()
+var symNameColor = colors.Bold().SprintFunc()
 
-var colorAddr = color.New(color.Faint).SprintfFunc()
-var colorImage = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
-var colorField = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-var colorClassField = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
+var colorAddr = colors.Faint().SprintfFunc()
+var colorImage = colors.BoldHiMagenta().SprintFunc()
+var colorField = colors.BoldHiBlue().SprintFunc()
+var colorClassField = colors.BoldHiMagenta().SprintFunc()
 
 type dscFunc struct {
 	Addr  uint64 `json:"addr,omitempty"`

--- a/cmd/ipsw/cmd/dyld/dyld_disass.go
+++ b/cmd/ipsw/cmd/dyld/dyld_disass.go
@@ -33,6 +33,7 @@ import (
 	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/apex/log"
 	"github.com/blacktop/ipsw/internal/ai"
+	"github.com/blacktop/ipsw/internal/colors"
 	dcmd "github.com/blacktop/ipsw/internal/commands/disass"
 	"github.com/blacktop/ipsw/pkg/disass"
 	"github.com/blacktop/ipsw/pkg/dyld"
@@ -239,7 +240,7 @@ var DisassCmd = &cobra.Command{
 						AsJSON:       asJSON,
 						Demangle:     demangleFlag,
 						Quiet:        quiet,
-						Color:        viper.GetBool("color") && !viper.GetBool("no-color") && !decompile,
+						Color:        colors.Active(),
 					})
 
 					if !quiet {
@@ -289,7 +290,7 @@ var DisassCmd = &cobra.Command{
 							Stream:         false,
 							DisableCache:   viper.GetBool("dyld.disass.dec-nocache"),
 							Verbose:        viper.GetBool("verbose"),
-							Color:          viper.GetBool("color") && !viper.GetBool("no-color"),
+							Color:          colors.Active(),
 							Theme:          viper.GetString("dyld.disass.dec-theme"),
 							MaxRetries:     viper.GetInt("dyld.disass.dec-retries"),
 							RetryBackoff:   viper.GetDuration("dyld.disass.dec-retry-backoff"),
@@ -356,7 +357,7 @@ var DisassCmd = &cobra.Command{
 						AsJSON:       asJSON,
 						Demangle:     demangleFlag,
 						Quiet:        quiet,
-						Color:        viper.GetBool("color") && !viper.GetBool("no-color") && !decompile,
+						Color:        colors.Active() && !decompile,
 					})
 
 					if !quiet {
@@ -411,7 +412,7 @@ var DisassCmd = &cobra.Command{
 							Stream:         false,
 							DisableCache:   viper.GetBool("dyld.disass.dec-nocache"),
 							Verbose:        viper.GetBool("verbose"),
-							Color:          viper.GetBool("color") && !viper.GetBool("no-color"),
+							Color:          colors.Active(),
 							Theme:          viper.GetString("dyld.disass.dec-theme"),
 							MaxRetries:     viper.GetInt("dyld.disass.dec-retries"),
 							RetryBackoff:   viper.GetDuration("dyld.disass.dec-retry-backoff"),
@@ -504,7 +505,7 @@ var DisassCmd = &cobra.Command{
 					AsJSON:       asJSON,
 					Demangle:     demangleFlag,
 					Quiet:        quiet,
-					Color:        viper.GetBool("color") && !viper.GetBool("no-color") && !decompile,
+					Color:        colors.Active() && !decompile,
 				})
 
 				if !quiet {
@@ -550,7 +551,7 @@ var DisassCmd = &cobra.Command{
 						Stream:         false,
 						DisableCache:   viper.GetBool("dyld.disass.dec-nocache"),
 						Verbose:        viper.GetBool("verbose"),
-						Color:          viper.GetBool("color") && !viper.GetBool("no-color"),
+						Color:          colors.Active(),
 						Theme:          viper.GetString("dyld.disass.dec-theme"),
 						MaxRetries:     viper.GetInt("dyld.disass.dec-retries"),
 						RetryBackoff:   viper.GetDuration("dyld.disass.dec-retry-backoff"),

--- a/cmd/ipsw/cmd/dyld/dyld_emu.go
+++ b/cmd/ipsw/cmd/dyld/dyld_emu.go
@@ -29,9 +29,9 @@ import (
 	"path/filepath"
 
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/pkg/dyld"
 	"github.com/blacktop/ipsw/pkg/emu"
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -110,7 +110,7 @@ var dyldEmuCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Print(color.New(color.Bold).Sprintf("\n%s:", symbolName))
+			fmt.Print(colors.Bold().Sprintf("\n%s:", symbolName))
 		} else {
 			image, err = f.GetImageContainingVMAddr(startAddr)
 			if err != nil {

--- a/cmd/ipsw/cmd/dyld/dyld_info.go
+++ b/cmd/ipsw/cmd/dyld/dyld_info.go
@@ -35,6 +35,7 @@ import (
 	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho"
+	"github.com/blacktop/ipsw/internal/colors"
 	dscCmd "github.com/blacktop/ipsw/internal/commands/dsc"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/dyld"
@@ -326,7 +327,7 @@ var dyldInfoCmd = &cobra.Command{
 					}
 					w.Flush()
 
-					if viper.GetBool("color") && !viper.GetBool("no-color") {
+					if colors.Active() {
 						if err := quick.Highlight(os.Stdout, buf.String(), "md", "terminal256", "nord"); err != nil {
 							return err
 						}
@@ -359,7 +360,10 @@ var dyldInfoCmd = &cobra.Command{
 					out, err := utils.GitDiff(
 						strings.Join(dout1, "\n")+"\n",
 						strings.Join(dout2, "\n")+"\n",
-						&utils.GitDiffConfig{Color: viper.GetBool("color") && !viper.GetBool("no-color"), Tool: viper.GetString("diff-tool")})
+						&utils.GitDiffConfig{
+							Color: colors.Active(),
+							Tool: viper.GetString("diff-tool"),
+						})
 					if err != nil {
 						return err
 					}

--- a/cmd/ipsw/cmd/dyld/dyld_macho.go
+++ b/cmd/ipsw/cmd/dyld/dyld_macho.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho/pkg/fixupchains"
 	"github.com/blacktop/go-macho/pkg/swift"
+	"github.com/blacktop/ipsw/internal/colors"
 	mcmd "github.com/blacktop/ipsw/internal/commands/macho"
 	"github.com/blacktop/ipsw/internal/demangle"
 	"github.com/blacktop/ipsw/pkg/dyld"
@@ -272,7 +273,7 @@ var MachoCmd = &cobra.Command{
 							Addrs:    true,
 							ObjcRefs: showObjcRefs,
 							Demangle: doDemangle,
-							Color:    viper.GetBool("color") && !viper.GetBool("no-color") && !viper.GetBool("no-color"),
+							Color:    colors.Active(),
 							Theme:    "nord",
 						})
 						if err != nil {
@@ -320,7 +321,7 @@ var MachoCmd = &cobra.Command{
 							Addrs:    true,
 							All:      showSwiftAll,
 							Demangle: doDemangle,
-							Color:    viper.GetBool("color") && !viper.GetBool("no-color") && !viper.GetBool("no-color"),
+							Color:    colors.Active(),
 							Theme:    "nord",
 						})
 						if err != nil {

--- a/cmd/ipsw/cmd/dyld/dyld_symaddr.go
+++ b/cmd/ipsw/cmd/dyld/dyld_symaddr.go
@@ -29,10 +29,10 @@ import (
 	"path/filepath"
 
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	dscCmd "github.com/blacktop/ipsw/internal/commands/dsc"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/dyld"
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -67,10 +67,6 @@ var SymAddrCmd = &cobra.Command{
 	},
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
-		useColor := viper.GetBool("color") && !viper.GetBool("no-color")
-		color.NoColor = !useColor
-
 		imageName := viper.GetString("dyld.symaddr.image")
 		symbolFile := viper.GetString("dyld.symaddr.in")
 		jsonFile := viper.GetString("dyld.symaddr.output")
@@ -150,7 +146,7 @@ var SymAddrCmd = &cobra.Command{
 				}
 
 				if lsym, err := i.GetSymbol(args[1]); err == nil {
-					fmt.Println(lsym.String(useColor))
+					fmt.Println(lsym.String(colors.Active()))
 				}
 
 				// if lsym, err := i.GetLocalSymbol(args[1]); err == nil {
@@ -179,7 +175,7 @@ var SymAddrCmd = &cobra.Command{
 					if !ok {
 						break
 					}
-					fmt.Println(sym.String(useColor))
+					fmt.Println(sym.String(colors.Active()))
 					if !allMatches {
 						return nil
 					}
@@ -189,7 +185,7 @@ var SymAddrCmd = &cobra.Command{
 				utils.Indent(log.Debug, 2)("Searching " + image.Name)
 				if sym, err := image.GetSymbol(args[1]); err == nil {
 					if (sym.Address > 0 || allMatches) && (sym.Kind != dyld.BIND || showBinds) {
-						fmt.Println(sym.String(useColor))
+						fmt.Println(sym.String(colors.Active()))
 						if !allMatches {
 							return nil
 						}

--- a/cmd/ipsw/cmd/dyld/dyld_webkit.go
+++ b/cmd/ipsw/cmd/dyld/dyld_webkit.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	dcsCmd "github.com/blacktop/ipsw/internal/commands/dsc"
 	"github.com/blacktop/ipsw/internal/download"
 	"github.com/blacktop/ipsw/internal/utils"
@@ -151,7 +152,10 @@ var WebkitCmd = &cobra.Command{
 			out, err := utils.GitDiff(
 				webkit1+"\n",
 				webkit2+"\n",
-				&utils.GitDiffConfig{Color: viper.GetBool("color") && !viper.GetBool("no-color"), Tool: viper.GetString("diff-tool")})
+				&utils.GitDiffConfig{
+					Color: colors.Active(),
+					Tool: viper.GetString("diff-tool"),
+				})
 			if err != nil {
 				return err
 			}

--- a/cmd/ipsw/cmd/ent.go
+++ b/cmd/ipsw/cmd/ent.go
@@ -28,7 +28,6 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/apex/log"
 	"github.com/blacktop/ipsw/internal/commands/ent"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -233,8 +232,6 @@ var entCmd = &cobra.Command{
 			}
 			return ent.CreateSQLiteDatabase(sqliteDB, ipsws, inputs)
 		}
-
-		color.NoColor = viper.GetBool("no-color") || fileOnly
 
 		if showStats {
 			if pgHost != "" {

--- a/cmd/ipsw/cmd/frida/types/objc.go
+++ b/cmd/ipsw/cmd/frida/types/objc.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/blacktop/ipsw/internal/colors"
 )
 
-var colorBold = color.New(color.Bold).SprintFunc()
-var colorHeader = color.New(color.FgHiBlue).SprintFunc()
-var ColorFaint = color.New(color.Faint, color.FgHiBlue).SprintFunc()
+var colorBold = colors.Bold().SprintFunc()
+var colorHeader = colors.HiBlue().SprintFunc()
+var ColorFaint = colors.FaintHiBlue().SprintFunc()
 
 type Argument struct {
 	TypeString        string `json:"typeString,omitempty"`

--- a/cmd/ipsw/cmd/fw/aea.go
+++ b/cmd/ipsw/cmd/fw/aea.go
@@ -32,9 +32,9 @@ import (
 
 	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/aea"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -101,8 +101,8 @@ var aeaCmd = &cobra.Command{
 			base64Key = strings.TrimPrefix(base64Key, "base64:")
 		}
 
-		var bold = color.New(color.Bold).SprintFunc()
-		var info = color.New(color.FgHiGreen).SprintFunc()
+		var bold = colors.Bold().SprintFunc()
+		var info = colors.HiGreen().SprintFunc()
 
 		if output == "" {
 			output = filepath.Dir(args[0])
@@ -126,7 +126,7 @@ var aeaCmd = &cobra.Command{
 				} else if b64data, err := base64.StdEncoding.WithPadding(base64.StdPadding).DecodeString(string(v)); err == nil {
 					fmt.Printf("%s:\n%s\n", bold("["+k+"]"), utils.HexDump(b64data, 0))
 				} else {
-					if viper.GetBool("color") && !viper.GetBool("no-color") {
+					if colors.Active() {
 						fmt.Println(bold("[" + k + "]"))
 						if err := quick.Highlight(os.Stdout, string(v)+"\n\n", "json", "terminal256", "nord"); err != nil {
 							return fmt.Errorf("failed to highlight json: %v", err)
@@ -154,7 +154,7 @@ var aeaCmd = &cobra.Command{
 			if err := os.WriteFile(fname, data, 0o644); err != nil {
 				return fmt.Errorf("failed to write private key to file: %v", err)
 			}
-			if viper.GetBool("color") && !viper.GetBool("no-color") {
+			if colors.Active() {
 				if err := quick.Highlight(os.Stdout, string(data)+"\n\n", "json", "terminal256", "nord"); err != nil {
 					return fmt.Errorf("failed to highlight json: %v", err)
 				}

--- a/cmd/ipsw/cmd/idev/idev_afc_tree.go
+++ b/cmd/ipsw/cmd/idev/idev_afc_tree.go
@@ -27,10 +27,10 @@ import (
 	"path/filepath"
 
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/usb/afc"
 	"github.com/dustin/go-humanize"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -73,8 +73,8 @@ var idevAfcTreeCmd = &cobra.Command{
 			fpath = args[0]
 		}
 
-		var dirColor = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-		var sizeColor = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
+		var dirColor = colors.BoldHiBlue().SprintFunc()
+		var sizeColor = colors.BoldHiMagenta().SprintFunc()
 
 		if flat {
 			if err := cli.Walk(fpath, func(path string, info os.FileInfo, err error) error {

--- a/cmd/ipsw/cmd/idev/idev_img_nonce.go
+++ b/cmd/ipsw/cmd/idev/idev_img_nonce.go
@@ -35,11 +35,11 @@ import (
 
 	"github.com/apex/log"
 	"github.com/blacktop/go-termimg"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/usb/mount"
 	"github.com/boombuler/barcode"
 	"github.com/boombuler/barcode/qr"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -185,19 +185,19 @@ var nonceCmd = &cobra.Command{
 
 		if readable {
 			if personalID != nil {
-				fmt.Printf("%s %d\n", color.New(color.Faint, color.FgHiBlue).Sprintf("ApBoardID: "), personalID["BoardId"])
-				fmt.Printf("%s %d\n", color.New(color.Faint, color.FgHiBlue).Sprintf("ApChipID:  "), personalID["ChipID"])
-				fmt.Printf("%s %d\n", color.New(color.Faint, color.FgHiBlue).Sprintf("ApECID:    "), personalID["UniqueChipID"])
+				fmt.Printf("%s %d\n", colors.FaintHiBlue().Sprintf("ApBoardID: "), personalID["BoardId"])
+				fmt.Printf("%s %d\n", colors.FaintHiBlue().Sprintf("ApChipID:  "), personalID["ChipID"])
+				fmt.Printf("%s %d\n", colors.FaintHiBlue().Sprintf("ApECID:    "), personalID["UniqueChipID"])
 			}
-			fmt.Println(color.New(color.Faint, color.FgHiBlue).Sprintf("Nonce:"))
+			fmt.Println(colors.FaintHiBlue().Sprintf("Nonce:"))
 			var out string
 			for i, c := range nonce {
 				if i > 0 && i%4 == 0 && i%24 != 0 {
-					out += color.New(color.Faint).Sprint("-")
+					out += colors.Faint().Sprint("-")
 				} else if i > 0 && i%24 == 0 {
 					out += "\n"
 				}
-				out += color.New(color.Bold).Sprintf("%c", c)
+				out += colors.Bold().Sprintf("%c", c)
 			}
 			fmt.Println(out)
 		} else {

--- a/cmd/ipsw/cmd/idev/idev_syslog.go
+++ b/cmd/ipsw/cmd/idev/idev_syslog.go
@@ -33,10 +33,10 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/usb/syslog"
 	"github.com/caarlos0/ctrlc"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -50,15 +50,15 @@ func init() {
 	viper.BindPFlag("idev.syslog.timeout", SyslogCmd.Flags().Lookup("timeout"))
 }
 
-var colorTime = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-var colorProc = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
-var colorLib = color.New(color.Bold, color.FgHiCyan).SprintFunc()
-var colorNotice = color.New(color.Bold, color.FgHiGreen).SprintFunc()
-var colorError = color.New(color.Bold, color.FgHiRed).SprintFunc()
-var colorErrorMsg = color.New(color.Faint, color.FgHiRed).SprintFunc()
-var colorWarning = color.New(color.Bold, color.FgHiYellow).SprintFunc()
-var colorWarningMsg = color.New(color.FgYellow).SprintFunc()
-var colorDebug = color.New(color.Bold, color.FgHiWhite).SprintFunc()
+var colorTime = colors.BoldHiBlue().SprintFunc()
+var colorProc = colors.BoldHiMagenta().SprintFunc()
+var colorLib = colors.BoldHiCyan().SprintFunc()
+var colorNotice = colors.BoldHiGreen().SprintFunc()
+var colorError = colors.BoldHiRed().SprintFunc()
+var colorErrorMsg = colors.FaintHiRed().SprintFunc()
+var colorWarning = colors.BoldHiYellow().SprintFunc()
+var colorWarningMsg = colors.Yellow().SprintFunc()
+var colorDebug = colors.BoldHiWhite().SprintFunc()
 
 func colorSyslog(line string) string {
 	re := regexp.MustCompile(`(?s)(?P<date>\w{3}\s\d{1,2}\s\d{2}:\d{2}:\d{2})\s(?P<device>\S+)\s(?P<proc>[a-zA-Z]+)(\((?P<lib>\S+)\))?\[(?P<pid>\S+)\]\s(?P<type>\S+)\s(?P<msg>.*)\n$`)
@@ -126,7 +126,7 @@ var SyslogCmd = &cobra.Command{
 			}
 			defer r.Close()
 
-			if viper.GetBool("color") && !viper.GetBool("no-color") {
+			if colors.Active() {
 				br := bufio.NewReader(r)
 				for {
 					line, err := br.ReadString('\x00')

--- a/cmd/ipsw/cmd/kernel/kernel_ctf.go
+++ b/cmd/ipsw/cmd/kernel/kernel_ctf.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho"
+	"github.com/blacktop/ipsw/internal/colors"
 	mcmd "github.com/blacktop/ipsw/internal/commands/macho"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/ctf"
@@ -150,7 +151,10 @@ var ctfdumpCmd = &cobra.Command{
 			out, err := utils.GitDiff(
 				t1.String(),
 				t2.String(),
-				&utils.GitDiffConfig{Color: viper.GetBool("color") && !viper.GetBool("no-color"), Tool: viper.GetString("diff-tool")})
+				&utils.GitDiffConfig{
+					Color: colors.Active(),
+					Tool: viper.GetString("diff-tool"),
+				})
 			if err != nil {
 				return err
 			}

--- a/cmd/ipsw/cmd/kernel/kernel_dwarf.go
+++ b/cmd/ipsw/cmd/kernel/kernel_dwarf.go
@@ -30,6 +30,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/commands/dwarf"
 	"github.com/blacktop/ipsw/internal/demangle"
 	"github.com/blacktop/ipsw/internal/utils"
@@ -273,7 +274,11 @@ var dwarfCmd = &cobra.Command{
 
 				for file2, typ2 := range t2 {
 					if typ1, found := t1[file2]; found {
-						out, err := utils.GitDiff(typ1, typ2, &utils.GitDiffConfig{Color: viper.GetBool("color") && !viper.GetBool("no-color"), Tool: viper.GetString("diff-tool")})
+						out, err := utils.GitDiff(typ1, typ2,
+							&utils.GitDiffConfig{
+								Color: colors.Active(),
+								Tool: viper.GetString("diff-tool"),
+							})
 						if err != nil {
 							return err
 						}
@@ -289,7 +294,7 @@ var dwarfCmd = &cobra.Command{
 			} else { // diff ALL structs
 				out, err := dwarf.DiffEnums(filepath.Clean(args[0]), filepath.Clean(args[1]), &dwarf.Config{
 					Markdown:    viper.GetBool("kernel.dwarf.md"),
-					Color:       viper.GetBool("color") && !viper.GetBool("no-color"),
+					Color:       colors.Active(),
 					DiffTool:    viper.GetString("diff-tool"),
 					ShowOffsets: !noOffsets,
 				})
@@ -303,7 +308,7 @@ var dwarfCmd = &cobra.Command{
 				log.Info("Diffing all structs")
 				out, err = dwarf.DiffStructures(filepath.Clean(args[0]), filepath.Clean(args[1]), &dwarf.Config{
 					Markdown:    viper.GetBool("kernel.dwarf.md"),
-					Color:       viper.GetBool("color") && !viper.GetBool("no-color"),
+					Color:       colors.Active(),
 					DiffTool:    viper.GetString("diff-tool"),
 					ShowOffsets: !noOffsets,
 				})
@@ -346,7 +351,7 @@ var dwarfCmd = &cobra.Command{
 						log.WithField("file", file).Info(viper.GetString("kernel.dwarf.type"))
 					}
 				}
-				fmt.Println(utils.ClangFormat(typ, viper.GetString("kernel.dwarf.type")+".h", viper.GetBool("color") && !viper.GetBool("no-color")))
+				fmt.Println(utils.ClangFormat(typ, viper.GetString("kernel.dwarf.type")+".h", colors.Active()))
 			}
 		}
 
@@ -365,9 +370,9 @@ var dwarfCmd = &cobra.Command{
 					if strings.HasPrefix(n.LinkageName, "__Z") || strings.HasPrefix(n.LinkageName, "_Z") {
 						n.LinkageName = demangle.Do("_"+n.LinkageName, false, false)
 					}
-					fmt.Printf("%#x: %s", n.LowPC, utils.ClangFormat(n.LinkageName, viper.GetString("kernel.dwarf.name")+".h", viper.GetBool("color") && !viper.GetBool("no-color")))
+					fmt.Printf("%#x: %s", n.LowPC, utils.ClangFormat(n.LinkageName, viper.GetString("kernel.dwarf.name")+".h", colors.Active()))
 				} else {
-					fmt.Printf("%#x: %s", n.LowPC, utils.ClangFormat(n.String(), viper.GetString("kernel.dwarf.name")+".h", viper.GetBool("color") && !viper.GetBool("no-color")))
+					fmt.Printf("%#x: %s", n.LowPC, utils.ClangFormat(n.String(), viper.GetString("kernel.dwarf.name")+".h", colors.Active()))
 				}
 			}
 		}
@@ -375,7 +380,7 @@ var dwarfCmd = &cobra.Command{
 		if viper.GetBool("kernel.dwarf.all") {
 			if err := dwarf.DumpAllTypes(filepath.Clean(args[0]), &dwarf.Config{
 				Markdown:    viper.GetBool("kernel.dwarf.md"),
-				Color:       viper.GetBool("color") && !viper.GetBool("no-color"),
+				Color:       colors.Active(),
 				DiffTool:    viper.GetString("diff-tool"),
 				ShowOffsets: !noOffsets,
 			}); err != nil {
@@ -385,7 +390,7 @@ var dwarfCmd = &cobra.Command{
 		if viper.GetBool("kernel.dwarf.structs") {
 			if err := dwarf.DumpAllStructs(filepath.Clean(args[0]), &dwarf.Config{
 				Markdown:    viper.GetBool("kernel.dwarf.md"),
-				Color:       viper.GetBool("color") && !viper.GetBool("no-color"),
+				Color:       colors.Active(),
 				DiffTool:    viper.GetString("diff-tool"),
 				ShowOffsets: !noOffsets,
 			}); err != nil {
@@ -395,7 +400,7 @@ var dwarfCmd = &cobra.Command{
 		if viper.GetBool("kernel.dwarf.enums") {
 			if err := dwarf.DumpAllEnums(filepath.Clean(args[0]), &dwarf.Config{
 				Markdown:    viper.GetBool("kernel.dwarf.md"),
-				Color:       viper.GetBool("color") && !viper.GetBool("no-color"),
+				Color:       colors.Active(),
 				DiffTool:    viper.GetString("diff-tool"),
 				ShowOffsets: !noOffsets,
 			}); err != nil {

--- a/cmd/ipsw/cmd/kernel/kernel_info.go
+++ b/cmd/ipsw/cmd/kernel/kernel_info.go
@@ -34,18 +34,18 @@ import (
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho/types"
 	mcmd "github.com/blacktop/ipsw/internal/commands/macho"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/magic"
 	"github.com/blacktop/ipsw/internal/utils"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var symAddrColor = color.New(color.Faint).SprintfFunc()
-var symImageColor = color.New(color.Faint, color.FgBlue).SprintfFunc()
-var symTypeColor = color.New(color.Faint, color.FgCyan).SprintfFunc()
-var symLibColor = color.New(color.Faint, color.FgMagenta).SprintfFunc()
-var symNameColor = color.New(color.Bold).SprintFunc()
+var symAddrColor = colors.Faint().SprintfFunc()
+var symImageColor = colors.FaintBlue().SprintfFunc()
+var symTypeColor = colors.FaintCyan().SprintfFunc()
+var symLibColor = colors.FaintMagenta().SprintfFunc()
+var symNameColor = colors.Bold().SprintFunc()
 
 func init() {
 	KernelcacheCmd.AddCommand(kernelInfoCmd)

--- a/cmd/ipsw/cmd/kernel/kernel_kexts.go
+++ b/cmd/ipsw/cmd/kernel/kernel_kexts.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	mcmd "github.com/blacktop/ipsw/internal/commands/macho"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/kernelcache"
@@ -98,7 +99,7 @@ var kextsCmd = &cobra.Command{
 			out, err := utils.GitDiff(
 				strings.Join(kout1, "\n"),
 				strings.Join(kout2, "\n"),
-				&utils.GitDiffConfig{Color: viper.GetBool("color") && !viper.GetBool("no-color"), Tool: viper.GetString("diff-tool")})
+				&utils.GitDiffConfig{Color: colors.Active(),Tool: viper.GetString("diff-tool")})
 			if err != nil {
 				return err
 			}

--- a/cmd/ipsw/cmd/macho/macho_disass.go
+++ b/cmd/ipsw/cmd/macho/macho_disass.go
@@ -33,6 +33,7 @@ import (
 	"github.com/blacktop/go-macho"
 	"github.com/blacktop/go-macho/types"
 	"github.com/blacktop/ipsw/internal/ai"
+	"github.com/blacktop/ipsw/internal/colors"
 	dcmd "github.com/blacktop/ipsw/internal/commands/disass"
 	mcmd "github.com/blacktop/ipsw/internal/commands/macho"
 	"github.com/blacktop/ipsw/internal/magic"
@@ -241,7 +242,7 @@ var machoDisassCmd = &cobra.Command{
 							AsJSON:       asJSON,
 							Demangle:     demangleFlag,
 							Quiet:        quiet,
-							Color:        viper.GetBool("color") && !viper.GetBool("no-color") && !decompile,
+							Color:        colors.Active() && !decompile,
 						})
 
 						//***********************
@@ -282,7 +283,7 @@ var machoDisassCmd = &cobra.Command{
 								Stream:         false,
 								DisableCache:   viper.GetBool("macho.disass.dec-nocache"),
 								Verbose:        viper.GetBool("verbose"),
-								Color:          viper.GetBool("color") && !viper.GetBool("no-color"),
+								Color:          colors.Active(),
 								Theme:          viper.GetString("macho.disass.dec-theme"),
 								MaxRetries:     viper.GetInt("macho.disass.dec-retries"),
 								RetryBackoff:   viper.GetDuration("macho.disass.dec-retry-backoff"),
@@ -369,7 +370,7 @@ var machoDisassCmd = &cobra.Command{
 						AsJSON:       asJSON,
 						Demangle:     demangleFlag,
 						Quiet:        quiet,
-						Color:        viper.GetBool("color") && !viper.GetBool("no-color") && !decompile,
+						Color:        colors.Active() && !decompile,
 					})
 
 					//***********************
@@ -413,7 +414,7 @@ var machoDisassCmd = &cobra.Command{
 							Stream:         false,
 							DisableCache:   viper.GetBool("macho.disass.dec-nocache"),
 							Verbose:        viper.GetBool("verbose"),
-							Color:          viper.GetBool("color") && !viper.GetBool("no-color"),
+							Color:          colors.Active(),
 							Theme:          viper.GetString("macho.disass.dec-theme"),
 							MaxRetries:     viper.GetInt("macho.disass.dec-retries"),
 							RetryBackoff:   viper.GetDuration("macho.disass.dec-retry-backoff"),

--- a/cmd/ipsw/cmd/macho/macho_info.go
+++ b/cmd/ipsw/cmd/macho/macho_info.go
@@ -43,12 +43,12 @@ import (
 	"github.com/blacktop/go-macho/types"
 	"github.com/blacktop/ipsw/internal/certs"
 	"github.com/blacktop/ipsw/internal/codesign/entitlements"
+	"github.com/blacktop/ipsw/internal/colors"
 	mcmd "github.com/blacktop/ipsw/internal/commands/macho"
 	"github.com/blacktop/ipsw/internal/demangle"
 	"github.com/blacktop/ipsw/internal/magic"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/plist"
-	"github.com/fatih/color"
 	"github.com/fullsailor/pkcs7"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -56,10 +56,10 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var symAddrColor = color.New(color.Faint).SprintfFunc()
-var symTypeColor = color.New(color.Faint, color.FgCyan).SprintfFunc()
-var symLibColor = color.New(color.Faint, color.FgMagenta).SprintfFunc()
-var symNameColor = color.New(color.Bold).SprintFunc()
+var symAddrColor = colors.Faint().SprintfFunc()
+var symTypeColor = colors.FaintCyan().SprintfFunc()
+var symLibColor = colors.FaintMagenta().SprintfFunc()
+var symNameColor = colors.Bold().SprintFunc()
 
 const (
 	onlyHeader       = 1 << 0
@@ -162,7 +162,7 @@ var machoInfoCmd = &cobra.Command{
 
 		// flags
 		verbose := viper.GetBool("verbose")
-		color := viper.GetBool("color") && !viper.GetBool("no-color")
+		color := colors.Active()
 
 		selectedArch := viper.GetString("macho.info.arch")
 		filesetEntry := viper.GetString("macho.info.fileset-entry")
@@ -786,7 +786,7 @@ var machoInfoCmd = &cobra.Command{
 					Addrs:    true,
 					ObjcRefs: showObjcRefs,
 					Demangle: doDemangle,
-					Color:    viper.GetBool("color") && !viper.GetBool("no-color") && !viper.GetBool("no-color"),
+					Color:    colors.Active(),
 					Theme:    "nord",
 				})
 				if err != nil {
@@ -812,7 +812,7 @@ var machoInfoCmd = &cobra.Command{
 					Addrs:    true,
 					All:      showSwiftAll,
 					Demangle: doDemangle,
-					Color:    viper.GetBool("color") && !viper.GetBool("no-color") && !viper.GetBool("no-color"),
+					Color:    colors.Active(),
 					Theme:    "nord",
 				})
 				if err != nil {

--- a/cmd/ipsw/cmd/macho/macho_search.go
+++ b/cmd/ipsw/cmd/macho/macho_search.go
@@ -34,9 +34,9 @@ import (
 	"github.com/blacktop/go-macho/pkg/swift"
 	"github.com/blacktop/go-macho/types/objc"
 	mcmd "github.com/blacktop/ipsw/internal/commands/macho"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/search"
 	"github.com/blacktop/ipsw/internal/utils"
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -54,9 +54,9 @@ func recurseProtocols(re *regexp.Regexp, proto objc.Protocol, depth int) (bool, 
 	return false, "", 0
 }
 
-var colorAddr = color.New(color.Faint).SprintfFunc()
-var colorImage = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
-var colorField = color.New(color.Bold, color.FgHiBlue).SprintFunc()
+var colorAddr = colors.Faint().SprintfFunc()
+var colorImage = colors.BoldHiMagenta().SprintFunc()
+var colorField = colors.BoldHiBlue().SprintFunc()
 
 func init() {
 	MachoCmd.AddCommand(machoSearchCmd)

--- a/cmd/ipsw/cmd/ota/ota.go
+++ b/cmd/ipsw/cmd/ota/ota.go
@@ -29,18 +29,18 @@ import (
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/pkg/ota"
 	"github.com/blacktop/ipsw/pkg/ota/types"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var colorMode = color.New(color.FgHiBlue).SprintFunc()
-var colorModTime = color.New(color.Faint).SprintFunc()
-var colorSize = color.New(color.FgHiCyan).SprintFunc()
-var colorName = color.New(color.Bold).SprintFunc()
-var colorLink = color.New(color.FgHiMagenta).SprintFunc()
+var colorMode = colors.HiBlue().SprintFunc()
+var colorModTime = colors.Faint().SprintFunc()
+var colorSize = colors.HiCyan().SprintFunc()
+var colorName = colors.Bold().SprintFunc()
+var colorLink = colors.HiMagenta().SprintFunc()
 
 // GetAEAKey looks up the AEA decryption key from the JSON database based on OTA filename
 func GetAEAKey(otaPath, keyDBPath string) (string, error) {

--- a/cmd/ipsw/cmd/pl.go
+++ b/cmd/ipsw/cmd/pl.go
@@ -37,6 +37,7 @@ import (
 	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/apex/log"
 	"github.com/blacktop/go-plist"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
@@ -244,7 +245,7 @@ var plistCmd = &cobra.Command{
 			return fmt.Errorf("failed to marshal json: %v", err)
 		}
 
-		if viper.GetBool("color") && !viper.GetBool("no-color") {
+		if colors.Active() {
 			if err := quick.Highlight(os.Stdout, string(jsonData)+"\n", "json", "terminal256", "nord"); err != nil {
 				return fmt.Errorf("failed to highlight json: %v", err)
 			}

--- a/cmd/ipsw/cmd/root.go
+++ b/cmd/ipsw/cmd/root.go
@@ -43,7 +43,7 @@ import (
 	"github.com/blacktop/ipsw/cmd/ipsw/cmd/ota"
 	"github.com/blacktop/ipsw/cmd/ipsw/cmd/sb"
 	"github.com/blacktop/ipsw/cmd/ipsw/cmd/ssh"
-	"github.com/fatih/color"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -66,7 +66,7 @@ var rootCmd = &cobra.Command{
 		if viper.GetBool("verbose") {
 			log.SetLevel(log.DebugLevel)
 		}
-		color.NoColor = viper.GetBool("no-color")
+		colors.Init()
 	},
 }
 

--- a/cmd/ipsw/cmd/sb/sb_diff.go
+++ b/cmd/ipsw/cmd/sb/sb_diff.go
@@ -34,10 +34,10 @@ import (
 
 	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/aea"
 	"github.com/blacktop/ipsw/pkg/info"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -187,19 +187,19 @@ var sbDiffCmd = &cobra.Command{
 		for _, f := range files {
 			newSbData := sbDBs[1][f]
 			if oldSbData, ok := sbDBs[0][f]; ok {
-				out, err := utils.GitDiff(oldSbData+"\n", newSbData+"\n", &utils.GitDiffConfig{Color: viper.GetBool("color") && !viper.GetBool("no-color")})
+				out, err := utils.GitDiff(oldSbData+"\n", newSbData+"\n", &utils.GitDiffConfig{Color: colors.Active()})
 				if err != nil {
 					return fmt.Errorf("failed to diff %s: %v", f, err)
 				}
 				if len(out) == 0 {
 					continue
 				}
-				fmt.Println(color.New(color.Bold).Sprintf("\n%s\n", f))
+				fmt.Println(colors.Bold().Sprintf("\n%s\n", f))
 				fmt.Println(" ╭╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴")
 				fmt.Println(out)
 				fmt.Println(" ╰╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴")
 			} else { // NEW sandbox profile
-				fmt.Println(color.New(color.Bold).Sprintf("\n🆕 %s\n", f))
+				fmt.Println(colors.Bold().Sprintf("\n🆕 %s\n", f))
 				fmt.Println(" ╭╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴")
 				quick.Highlight(os.Stdout, newSbData, "scheme", "terminal256", "nord")
 				fmt.Println(" ╰╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴")

--- a/cmd/ipsw/cmd/swift_dump.go
+++ b/cmd/ipsw/cmd/swift_dump.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho"
 	"github.com/blacktop/go-macho/pkg/swift"
+	"github.com/blacktop/ipsw/internal/colors"
 	mcmd "github.com/blacktop/ipsw/internal/commands/macho"
 	"github.com/blacktop/ipsw/internal/demangle"
 	"github.com/blacktop/ipsw/internal/magic"
@@ -135,7 +136,7 @@ var swiftDumpCmd = &cobra.Command{
 			Deps:        viper.GetBool("swift-dump.deps"),
 			Demangle:    doDemangle,
 			IpswVersion: fmt.Sprintf("Version: %s, BuildCommit: %s", strings.TrimSpace(AppVersion), strings.TrimSpace(AppBuildCommit)),
-			Color:       viper.GetBool("color") && !viper.GetBool("no-color"),
+			Color:       colors.Active(),
 			Theme:       viper.GetString("swift-dump.theme"),
 			Output:      viper.GetString("swift-dump.output"),
 			Headers:     viper.GetBool("swift-dump.headers"),

--- a/cmd/ipsw/cmd/watch.go
+++ b/cmd/ipsw/cmd/watch.go
@@ -33,12 +33,12 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/commands/watch"
 	"github.com/blacktop/ipsw/internal/commands/watch/announce"
 	watchgit "github.com/blacktop/ipsw/internal/commands/watch/git"
 	"github.com/blacktop/ipsw/internal/download"
 	"github.com/blacktop/ipsw/internal/utils"
-	"github.com/fatih/color"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
@@ -46,9 +46,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-var colorHeader = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-var colorHighlight = color.New(color.Bold, color.BgHiYellow).SprintfFunc()
-var colorSeparator = color.New(color.Faint).SprintFunc()
+var colorHeader = colors.BoldHiBlue().SprintFunc()
+var colorHighlight = colors.BoldOnHiYellow().SprintfFunc()
+var colorSeparator = colors.Faint().SprintFunc()
 
 func highlightHeader(re *regexp.Regexp, input string) string {
 	parts := re.FindAllStringIndex(input, -1)
@@ -364,7 +364,7 @@ var watchCmd = &cobra.Command{
 					} else {
 						diff, err := utils.GitDiff(previousContent, latestChange.Content,
 							&utils.GitDiffConfig{
-								Color: viper.GetBool("color") && !viper.GetBool("no-color"),
+								Color: colors.Active(),
 								Tool:  viper.GetString("diff-tool"),
 							})
 						if err != nil {

--- a/internal/colors/colors.go
+++ b/internal/colors/colors.go
@@ -1,0 +1,127 @@
+// Centralized TTY-aware color output management.
+// Requires initialization (Init) to be called after cli parsing has been done - 
+// from cobra PersistentPreRun() callback
+
+package colors
+
+import (
+	"github.com/fatih/color"
+	"github.com/spf13/viper"
+)
+
+func Init() {
+	// color.NoColor already set by fatih/color init() based on:
+	// TTY detection, Cygwin terminal, TERM=dumb, NO_COLOR env
+	isTTY := !color.NoColor
+
+	noColor := viper.GetBool("no-color")
+	forceColor := viper.GetBool("color") && !noColor
+
+	color.NoColor = noColor || !(isTTY || forceColor)
+}
+
+// Active reports whether color output is active.
+// Determined by TTY detection, --color, and --no-color flags.
+func Active() bool {
+	return !color.NoColor
+}
+
+// New creates a color with custom attributes. Use for combinations not covered
+// by the convenience functions below.
+func New(attrs ...color.Attribute) *color.Color {
+	return color.New(attrs...)
+}
+
+// -----------------------------------------------------------------------------
+// Basic styles
+// -----------------------------------------------------------------------------
+
+func Bold() *color.Color   { return color.New(color.Bold) }
+func Faint() *color.Color  { return color.New(color.Faint) }
+func Italic() *color.Color { return color.New(color.Italic) }
+
+// -----------------------------------------------------------------------------
+// Foreground colors
+// -----------------------------------------------------------------------------
+
+func Red() *color.Color     { return color.New(color.FgRed) }
+func Green() *color.Color   { return color.New(color.FgGreen) }
+func Yellow() *color.Color  { return color.New(color.FgYellow) }
+func Blue() *color.Color    { return color.New(color.FgBlue) }
+func Magenta() *color.Color { return color.New(color.FgMagenta) }
+func Cyan() *color.Color    { return color.New(color.FgCyan) }
+func White() *color.Color   { return color.New(color.FgWhite) }
+
+// -----------------------------------------------------------------------------
+// High-intensity foreground colors
+// -----------------------------------------------------------------------------
+
+func HiRed() *color.Color     { return color.New(color.FgHiRed) }
+func HiGreen() *color.Color   { return color.New(color.FgHiGreen) }
+func HiYellow() *color.Color  { return color.New(color.FgHiYellow) }
+func HiBlue() *color.Color    { return color.New(color.FgHiBlue) }
+func HiMagenta() *color.Color { return color.New(color.FgHiMagenta) }
+func HiCyan() *color.Color    { return color.New(color.FgHiCyan) }
+func HiWhite() *color.Color   { return color.New(color.FgHiWhite) }
+
+// -----------------------------------------------------------------------------
+// Bold + foreground combinations
+// -----------------------------------------------------------------------------
+
+func BoldRed() *color.Color     { return color.New(color.Bold, color.FgRed) }
+func BoldGreen() *color.Color   { return color.New(color.Bold, color.FgGreen) }
+func BoldYellow() *color.Color  { return color.New(color.Bold, color.FgYellow) }
+func BoldBlue() *color.Color    { return color.New(color.Bold, color.FgBlue) }
+func BoldMagenta() *color.Color { return color.New(color.Bold, color.FgMagenta) }
+func BoldCyan() *color.Color    { return color.New(color.Bold, color.FgCyan) }
+func BoldWhite() *color.Color   { return color.New(color.Bold, color.FgWhite) }
+
+func BoldHiRed() *color.Color     { return color.New(color.Bold, color.FgHiRed) }
+func BoldHiGreen() *color.Color   { return color.New(color.Bold, color.FgHiGreen) }
+func BoldHiYellow() *color.Color  { return color.New(color.Bold, color.FgHiYellow) }
+func BoldHiBlue() *color.Color    { return color.New(color.Bold, color.FgHiBlue) }
+func BoldHiMagenta() *color.Color { return color.New(color.Bold, color.FgHiMagenta) }
+func BoldHiCyan() *color.Color    { return color.New(color.Bold, color.FgHiCyan) }
+func BoldHiWhite() *color.Color   { return color.New(color.Bold, color.FgHiWhite) }
+
+// -----------------------------------------------------------------------------
+// Faint + foreground combinations
+// -----------------------------------------------------------------------------
+
+func FaintRed() *color.Color     { return color.New(color.Faint, color.FgRed) }
+func FaintGreen() *color.Color   { return color.New(color.Faint, color.FgGreen) }
+func FaintYellow() *color.Color  { return color.New(color.Faint, color.FgYellow) }
+func FaintBlue() *color.Color    { return color.New(color.Faint, color.FgBlue) }
+func FaintMagenta() *color.Color { return color.New(color.Faint, color.FgMagenta) }
+func FaintCyan() *color.Color    { return color.New(color.Faint, color.FgCyan) }
+func FaintWhite() *color.Color   { return color.New(color.Faint, color.FgWhite) }
+
+func FaintHiRed() *color.Color     { return color.New(color.Faint, color.FgHiRed) }
+func FaintHiGreen() *color.Color   { return color.New(color.Faint, color.FgHiGreen) }
+func FaintHiYellow() *color.Color  { return color.New(color.Faint, color.FgHiYellow) }
+func FaintHiBlue() *color.Color    { return color.New(color.Faint, color.FgHiBlue) }
+func FaintHiMagenta() *color.Color { return color.New(color.Faint, color.FgHiMagenta) }
+func FaintHiCyan() *color.Color    { return color.New(color.Faint, color.FgHiCyan) }
+func FaintHiWhite() *color.Color   { return color.New(color.Faint, color.FgHiWhite) }
+
+// -----------------------------------------------------------------------------
+// Italic combinations
+// -----------------------------------------------------------------------------
+
+func ItalicFaint() *color.Color      { return color.New(color.Italic, color.Faint) }
+func ItalicFaintWhite() *color.Color { return color.New(color.Italic, color.Faint, color.FgWhite) }
+func ItalicBoldHiYellow() *color.Color {
+	return color.New(color.Italic, color.Bold, color.FgHiYellow)
+}
+
+// -----------------------------------------------------------------------------
+// Background combinations
+// -----------------------------------------------------------------------------
+
+func BoldBlackOnHiWhite() *color.Color {
+	return color.New(color.Bold, color.FgBlack, color.BgHiWhite)
+}
+
+func BoldOnHiYellow() *color.Color {
+	return color.New(color.Bold, color.BgHiYellow)
+}

--- a/internal/colors/colors_test.go
+++ b/internal/colors/colors_test.go
@@ -1,0 +1,182 @@
+package colors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+func TestInit_ForceOn(t *testing.T) {
+	// Save and restore original state
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+
+	color.NoColor = true // start disabled
+	forceOn := true
+	Init(&forceOn)
+
+	if color.NoColor {
+		t.Error("expected colors enabled when Init(true)")
+	}
+	if !Enabled() {
+		t.Error("Enabled() should return true")
+	}
+}
+
+func TestInit_ForceOff(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+
+	color.NoColor = false // start enabled
+	forceOff := false
+	Init(&forceOff)
+
+	if !color.NoColor {
+		t.Error("expected colors disabled when Init(false)")
+	}
+	if Enabled() {
+		t.Error("Enabled() should return false")
+	}
+}
+
+func TestInit_Nil_KeepsExisting(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+
+	// Test with colors enabled
+	color.NoColor = false
+	Init(nil)
+	if color.NoColor {
+		t.Error("Init(nil) should not change NoColor when it was false")
+	}
+
+	// Test with colors disabled
+	color.NoColor = true
+	Init(nil)
+	if !color.NoColor {
+		t.Error("Init(nil) should not change NoColor when it was true")
+	}
+}
+
+func TestColorOutput_Enabled(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+
+	color.NoColor = false
+
+	result := Bold().Sprint("test")
+	if !strings.Contains(result, "\x1b[") {
+		t.Errorf("expected ANSI codes when colors enabled, got: %q", result)
+	}
+}
+
+func TestColorOutput_Disabled(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+
+	color.NoColor = true
+
+	result := Bold().Sprint("test")
+	if strings.Contains(result, "\x1b[") {
+		t.Errorf("expected no ANSI codes when colors disabled, got: %q", result)
+	}
+	if result != "test" {
+		t.Errorf("expected plain 'test', got: %q", result)
+	}
+}
+
+func TestAllConstructors(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+
+	color.NoColor = false
+
+	// Just verify they don't panic and return non-nil
+	constructors := []struct {
+		name string
+		fn   func() *color.Color
+	}{
+		{"Bold", Bold},
+		{"Faint", Faint},
+		{"Italic", Italic},
+		{"Red", Red},
+		{"Green", Green},
+		{"Yellow", Yellow},
+		{"Blue", Blue},
+		{"Magenta", Magenta},
+		{"Cyan", Cyan},
+		{"White", White},
+		{"HiRed", HiRed},
+		{"HiGreen", HiGreen},
+		{"HiYellow", HiYellow},
+		{"HiBlue", HiBlue},
+		{"HiMagenta", HiMagenta},
+		{"HiCyan", HiCyan},
+		{"HiWhite", HiWhite},
+		{"BoldRed", BoldRed},
+		{"BoldGreen", BoldGreen},
+		{"BoldYellow", BoldYellow},
+		{"BoldBlue", BoldBlue},
+		{"BoldMagenta", BoldMagenta},
+		{"BoldCyan", BoldCyan},
+		{"BoldWhite", BoldWhite},
+		{"BoldHiRed", BoldHiRed},
+		{"BoldHiGreen", BoldHiGreen},
+		{"BoldHiYellow", BoldHiYellow},
+		{"BoldHiBlue", BoldHiBlue},
+		{"BoldHiMagenta", BoldHiMagenta},
+		{"BoldHiCyan", BoldHiCyan},
+		{"BoldHiWhite", BoldHiWhite},
+		{"FaintRed", FaintRed},
+		{"FaintGreen", FaintGreen},
+		{"FaintYellow", FaintYellow},
+		{"FaintBlue", FaintBlue},
+		{"FaintMagenta", FaintMagenta},
+		{"FaintCyan", FaintCyan},
+		{"FaintWhite", FaintWhite},
+		{"FaintHiRed", FaintHiRed},
+		{"FaintHiGreen", FaintHiGreen},
+		{"FaintHiYellow", FaintHiYellow},
+		{"FaintHiBlue", FaintHiBlue},
+		{"FaintHiMagenta", FaintHiMagenta},
+		{"FaintHiCyan", FaintHiCyan},
+		{"FaintHiWhite", FaintHiWhite},
+		{"ItalicFaint", ItalicFaint},
+		{"ItalicFaintWhite", ItalicFaintWhite},
+		{"ItalicBoldHiYellow", ItalicBoldHiYellow},
+		{"BoldBlackOnHiWhite", BoldBlackOnHiWhite},
+		{"BoldOnHiYellow", BoldOnHiYellow},
+	}
+
+	for _, tc := range constructors {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.fn()
+			if c == nil {
+				t.Errorf("%s() returned nil", tc.name)
+				return
+			}
+			result := c.Sprint("x")
+			if result == "" {
+				t.Errorf("%s().Sprint() returned empty", tc.name)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+
+	color.NoColor = false
+
+	c := New(color.Bold, color.FgRed, color.BgWhite)
+	if c == nil {
+		t.Fatal("New() returned nil")
+	}
+
+	result := c.Sprint("test")
+	if !strings.Contains(result, "\x1b[") {
+		t.Errorf("New() color should produce ANSI codes, got: %q", result)
+	}
+}

--- a/internal/commands/disass/disass.go
+++ b/internal/commands/disass/disass.go
@@ -16,9 +16,9 @@ import (
 	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/apex/log"
 	"github.com/blacktop/ipsw/internal/ai"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/pkg/disass"
 	"github.com/briandowns/spinner"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -104,7 +104,7 @@ func Decompile(asm string, cfg *Config) (string, error) {
 
 decompile:
 	s := spinner.New(spinner.CharSets[38], 100*time.Millisecond)
-	s.Prefix = color.BlueString("   • Decompiling... ")
+	s.Prefix = colors.Blue().Sprint("   • Decompiling... ")
 	s.Start()
 
 	decmp, err := llm.Chat()

--- a/internal/commands/ent/ent.go
+++ b/internal/commands/ent/ent.go
@@ -21,10 +21,10 @@ import (
 	"github.com/blacktop/go-macho"
 	cstypes "github.com/blacktop/go-macho/pkg/codesign/types"
 	ents "github.com/blacktop/ipsw/internal/codesign/entitlements"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/aea"
 	"github.com/blacktop/ipsw/pkg/info"
-	"github.com/fatih/color"
 )
 
 // Entitlements is a map of entitlements
@@ -275,7 +275,7 @@ func DiffDatabases(db1, db2 map[string]string, conf *Config) (string, error) {
 				buf.WriteString(fmt.Sprintf("### %s\n\n> `%s`\n\n", filepath.Base(f2), f2))
 				buf.WriteString("```diff\n" + out + "\n```\n")
 			} else {
-				buf.WriteString(color.New(color.Bold).Sprintf("\n%s\n\n", f2))
+				buf.WriteString(colors.Bold().Sprintf("\n%s\n\n", f2))
 				buf.WriteString(out + "\n")
 			}
 		} else {
@@ -283,7 +283,7 @@ func DiffDatabases(db1, db2 map[string]string, conf *Config) (string, error) {
 			if conf.Markdown {
 				buf.WriteString(fmt.Sprintf("\n### 🆕 %s\n\n> `%s`\n\n", filepath.Base(f2), f2))
 			} else {
-				buf.WriteString(color.New(color.Bold).Sprintf("\n🆕 %s\n\n", f2))
+				buf.WriteString(colors.Bold().Sprintf("\n🆕 %s\n\n", f2))
 			}
 			if len(e2) == 0 {
 				buf.WriteString("- No entitlements *(yet)*\n")

--- a/internal/commands/ent/operations.go
+++ b/internal/commands/ent/operations.go
@@ -8,16 +8,16 @@ import (
 	"text/tabwriter"
 
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/db"
 	"github.com/blacktop/ipsw/pkg/info"
 	"github.com/dustin/go-humanize"
-	"github.com/fatih/color"
 )
 
-var colorBin = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
-var colorKey = color.New(color.Bold, color.FgHiGreen).SprintFunc()
-var colorValue = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-var colorVersion = color.New(color.Bold, color.FgCyan).SprintFunc()
+var colorBin = colors.BoldHiMagenta().SprintFunc()
+var colorKey = colors.BoldHiGreen().SprintFunc()
+var colorValue = colors.BoldHiBlue().SprintFunc()
+var colorVersion = colors.BoldCyan().SprintFunc()
 
 // CreateSQLiteDatabase creates or updates the SQLite database
 func CreateSQLiteDatabase(dbPath string, ipsws, inputs []string) error {

--- a/internal/download/pcc.go
+++ b/internal/download/pcc.go
@@ -19,9 +19,9 @@ import (
 	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/apex/log"
 	"github.com/blacktop/go-plist"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/download/pcc"
 	"github.com/blacktop/ipsw/internal/utils"
-	"github.com/fatih/color"
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/proto"
 )
@@ -81,12 +81,12 @@ type Ticket struct {
 	CryptexTickets []asn1.RawValue `asn1:"set"`
 }
 
-var colorField = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-var colorTypeField = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
-var colorHash = color.New(color.Faint).SprintfFunc()
-var colorName = color.New(color.Bold).SprintfFunc()
-var colorCreateTime = color.New(color.Faint, color.FgGreen).SprintFunc()
-var colorExpireTime = color.New(color.Faint, color.FgRed).SprintFunc()
+var colorField = colors.BoldHiBlue().SprintFunc()
+var colorTypeField = colors.BoldHiMagenta().SprintFunc()
+var colorHash = colors.Faint().SprintfFunc()
+var colorName = colors.Bold().SprintfFunc()
+var colorCreateTime = colors.FaintGreen().SprintFunc()
+var colorExpireTime = colors.FaintRed().SprintFunc()
 
 type PCCRelease struct {
 	Index uint64
@@ -127,7 +127,7 @@ func (r PCCRelease) String() string {
 	}
 	out += colorField("DarwinInit:\n")
 	dat, _ := json.MarshalIndent(r.DarwinInit.AsMap(), "", "  ")
-	if color.NoColor {
+	if !colors.Active() {
 		out += string(dat)
 	} else {
 		var buf strings.Builder

--- a/internal/utils/hexdump.go
+++ b/internal/utils/hexdump.go
@@ -7,12 +7,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/blacktop/ipsw/internal/colors"
 )
 
 // CREDIT: https://pkg.go.dev/encoding/hex (edited to add vaddr and color)
 
-var colorFaint = color.New(color.Faint, color.FgHiBlue).SprintFunc()
+var colorFaint = colors.FaintHiBlue().SprintFunc()
 
 func colorZeros(dump string) string {
 	if len(dump) > 0 {
@@ -90,7 +90,7 @@ func (h *dumper) Write(data []byte) (n int, err error) {
 			h.buf[24] = ':'
 			h.buf[25] = ' '
 			h.buf[26] = ' '
-			color.New(color.Italic, color.Faint).Fprint(h.w, string(h.buf[8:25]))
+			colors.ItalicFaint().Fprint(h.w, string(h.buf[8:25]))
 			_, err = h.w.Write(h.buf[25:])
 			if err != nil {
 				return

--- a/pkg/crashlog/ips.go
+++ b/pkg/crashlog/ips.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blacktop/go-macho"
 	"github.com/blacktop/go-macho/pkg/swift"
 	"github.com/blacktop/go-macho/types"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/commands/dsc"
 	"github.com/blacktop/ipsw/internal/commands/extract"
 	"github.com/blacktop/ipsw/internal/demangle"
@@ -32,7 +33,6 @@ import (
 	"github.com/blacktop/ipsw/pkg/disass"
 	"github.com/blacktop/ipsw/pkg/info"
 	"github.com/blacktop/ipsw/pkg/signature"
-	"github.com/fatih/color"
 	"github.com/go-viper/mapstructure/v2"
 )
 
@@ -43,12 +43,12 @@ import (
 //go:embed data/log_type.gz
 var logTypeData []byte
 
-var colorTime = color.New(color.Bold, color.FgHiGreen).SprintFunc()
-var colorError = color.New(color.Bold, color.FgHiRed).SprintFunc()
-var colorAddr = color.New(color.Faint).SprintfFunc()
-var colorBold = color.New(color.Bold).SprintfFunc()
-var colorImage = color.New(color.Bold, color.FgHiMagenta).SprintfFunc()
-var colorField = color.New(color.Bold, color.FgHiBlue).SprintFunc()
+var colorTime = colors.BoldHiGreen().SprintFunc()
+var colorError = colors.BoldHiRed().SprintFunc()
+var colorAddr = colors.Faint().SprintfFunc()
+var colorBold = colors.Bold().SprintfFunc()
+var colorImage = colors.BoldHiMagenta().SprintfFunc()
+var colorField = colors.BoldHiBlue().SprintFunc()
 
 var ErrDone = errors.New("done")
 

--- a/pkg/ddi/ddi.go
+++ b/pkg/ddi/ddi.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/blacktop/ipsw/internal/colors"
 )
 
 const (
@@ -33,7 +33,7 @@ type Platform struct {
 	HostDDI string `json:"hostDDI"`
 }
 
-var colorField = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
+var colorField = colors.BoldHiMagenta().SprintFunc()
 
 func (p *Platform) String() string {
 	var fields []string

--- a/pkg/disass/colors.go
+++ b/pkg/disass/colors.go
@@ -3,18 +3,18 @@ package disass
 import (
 	"regexp"
 
-	"github.com/fatih/color"
+	"github.com/blacktop/ipsw/internal/colors"
 )
 
 // disassembly colors
-var colorOp = color.New(color.Bold).SprintfFunc()
-var colorRegs = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-var colorImm = color.New(color.Bold, color.FgMagenta).SprintFunc()
-var colorAddr = color.New(color.Bold, color.FgMagenta).SprintfFunc()
-var colorOpCodes = color.New(color.Faint, color.FgHiWhite).SprintFunc()
-var colorComment = color.New(color.Faint, color.FgWhite).SprintFunc()
-var colorLocation = color.New(color.FgHiYellow).SprintfFunc()
-var printCurLine = color.New(color.Bold, color.FgBlack, color.BgHiWhite).PrintfFunc()
+var colorOp = colors.Bold().SprintfFunc()
+var colorRegs = colors.BoldHiBlue().SprintFunc()
+var colorImm = colors.BoldMagenta().SprintFunc()
+var colorAddr = colors.BoldMagenta().SprintfFunc()
+var colorOpCodes = colors.FaintHiWhite().SprintFunc()
+var colorComment = colors.FaintWhite().SprintFunc()
+var colorLocation = colors.HiYellow().SprintfFunc()
+var printCurLine = colors.BoldBlackOnHiWhite().PrintfFunc()
 
 func ColorOperands(operands string) string {
 	if len(operands) > 0 {

--- a/pkg/dyld/symbols.go
+++ b/pkg/dyld/symbols.go
@@ -16,8 +16,8 @@ import (
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho/pkg/trie"
 	"github.com/blacktop/go-macho/types"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
@@ -70,11 +70,11 @@ type Symbol struct {
 	Kind    symKind `json:"-"`
 }
 
-var symDarkAddrColor = color.New(color.Bold, color.FgBlue).SprintfFunc()
-var symAddrColor = color.New(color.Bold, color.FgMagenta).SprintfFunc()
-var symTypeColor = color.New(color.FgGreen).SprintfFunc()
-var symNameColor = color.New(color.Bold).SprintFunc()
-var symImageColor = color.New(color.Faint, color.FgHiWhite).SprintfFunc()
+var symDarkAddrColor = colors.BoldBlue().SprintfFunc()
+var symAddrColor = colors.BoldMagenta().SprintfFunc()
+var symTypeColor = colors.Green().SprintfFunc()
+var symNameColor = colors.Bold().SprintFunc()
+var symImageColor = colors.FaintHiWhite().SprintfFunc()
 
 func (s Symbol) String(color bool) string {
 	if color {

--- a/pkg/emu/colors.go
+++ b/pkg/emu/colors.go
@@ -2,17 +2,17 @@
 
 package emu
 
-import "github.com/fatih/color"
+import "github.com/blacktop/ipsw/internal/colors"
 
 // disassembly colors
-var colorOp = color.New(color.Bold).SprintfFunc()
-var colorRegs = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-var colorImm = color.New(color.Bold, color.FgMagenta).SprintFunc()
-var colorAddr = color.New(color.Bold, color.FgMagenta).SprintfFunc()
-var colorOpCodes = color.New(color.Faint, color.FgHiWhite).SprintFunc()
+var colorOp = colors.Bold().SprintfFunc()
+var colorRegs = colors.BoldHiBlue().SprintFunc()
+var colorImm = colors.BoldMagenta().SprintFunc()
+var colorAddr = colors.BoldMagenta().SprintfFunc()
+var colorOpCodes = colors.FaintHiWhite().SprintFunc()
 
 // hook colors
-var colorHook = color.New(color.Faint, color.FgHiBlue).SprintFunc()
-var colorDetails = color.New(color.Italic, color.Faint, color.FgWhite).SprintfFunc()
-var colorInterrupt = color.New(color.Italic, color.Bold, color.FgHiYellow).SprintfFunc()
-var colorChanged = color.New(color.FgHiYellow).SprintfFunc()
+var colorHook = colors.FaintHiBlue().SprintFunc()
+var colorDetails = colors.ItalicFaintWhite().SprintfFunc()
+var colorInterrupt = colors.ItalicBoldHiYellow().SprintfFunc()
+var colorChanged = colors.HiYellow().SprintfFunc()

--- a/pkg/img4/img4.go
+++ b/pkg/img4/img4.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/fatih/color"
+	"github.com/blacktop/ipsw/internal/colors"
 )
 
 // Color variables are defined in manifest.go
 var (
-	colorTitle    = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
-	colorField    = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-	colorSubField = color.New(color.Bold, color.FgHiCyan).SprintFunc()
+	colorTitle    = colors.BoldHiMagenta().SprintFunc()
+	colorField    = colors.BoldHiBlue().SprintFunc()
+	colorSubField = colors.BoldHiCyan().SprintFunc()
 )
 
 // ComponentFourCCs is a map of component names to their four-character codes.

--- a/pkg/img4/manifest.go
+++ b/pkg/img4/manifest.go
@@ -16,17 +16,17 @@ import (
 
 	"github.com/apex/log"
 	"github.com/blacktop/go-plist"
+	"github.com/blacktop/ipsw/internal/colors"
 	bm "github.com/blacktop/ipsw/pkg/plist"
-	"github.com/fatih/color"
 )
 
 // Color functions for verification output
 var (
-	colorSuccess  = color.New(color.FgGreen).SprintFunc()
-	colorError    = color.New(color.FgRed).SprintFunc()
-	colorWarning  = color.New(color.FgYellow).SprintFunc()
-	colorInfo     = color.New(color.FgCyan).SprintFunc()
-	colorLongName = color.New(color.FgHiYellow).SprintFunc()
+	colorSuccess  = colors.Green().SprintFunc()
+	colorError    = colors.Red().SprintFunc()
+	colorWarning  = colors.Yellow().SprintFunc()
+	colorInfo     = colors.Cyan().SprintFunc()
+	colorLongName = colors.HiYellow().SprintFunc()
 )
 
 // Core ASN.1 Private Tag Constants (stable tags that won't change)

--- a/pkg/info/db.go
+++ b/pkg/info/db.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/ota/types"
 	"github.com/blacktop/ipsw/pkg/xcode"
-	"github.com/fatih/color"
 )
 
 //go:embed data/ipsw_db.gz
@@ -44,9 +44,9 @@ type Device struct {
 
 type Devices map[string]Device
 
-var colorName = color.New(color.Bold).SprintFunc()
-var colorBoard = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
-var colorField = color.New(color.Bold, color.FgHiBlue).SprintFunc()
+var colorName = colors.Bold().SprintFunc()
+var colorBoard = colors.BoldHiMagenta().SprintFunc()
+var colorField = colors.BoldHiBlue().SprintFunc()
 
 func (d Device) String() string {
 	var sb strings.Builder

--- a/pkg/kernelcache/mach_trap.go
+++ b/pkg/kernelcache/mach_trap.go
@@ -13,8 +13,8 @@ import (
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho"
 	"github.com/blacktop/go-macho/types"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/pkg/disass"
-	"github.com/fatih/color"
 )
 
 const (
@@ -87,12 +87,12 @@ func (s SyscallsData) GetBsdSyscallByNumber(num int) (BsdSyscall, error) {
 	return BsdSyscall{}, fmt.Errorf("mach trap %d not found", num)
 }
 
-var colorAddr = color.New(color.Faint).SprintfFunc()
-var colorBold = color.New(color.Bold).SprintFunc()
-var colorField = color.New(color.Bold, color.FgHiCyan).SprintFunc()
-var colorName = color.New(color.Bold, color.FgHiBlue).SprintFunc()
-var colorType = color.New(color.Bold, color.FgHiYellow).SprintFunc()
-var colorSubSystem = color.New(color.Bold, color.FgHiMagenta).SprintFunc()
+var colorAddr = colors.Faint().SprintfFunc()
+var colorBold = colors.Bold().SprintFunc()
+var colorField = colors.BoldHiCyan().SprintFunc()
+var colorName = colors.BoldHiBlue().SprintFunc()
+var colorType = colors.BoldHiYellow().SprintFunc()
+var colorSubSystem = colors.BoldHiMagenta().SprintFunc()
 
 func (m MachTrap) String() string {
 	var funcStr string

--- a/pkg/usb/diagnostics/diagnostics.go
+++ b/pkg/usb/diagnostics/diagnostics.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/pkg/usb"
 	"github.com/blacktop/ipsw/pkg/usb/lockdownd"
-	"github.com/fatih/color"
 )
 
 const (
@@ -16,9 +16,9 @@ const (
 	oldServiceName = "com.apple.iosdiagnostics.relay"
 )
 
-var colorHeader = color.New(color.FgHiBlue).SprintFunc()
-var colorFaint = color.New(color.Faint, color.FgHiBlue).SprintFunc()
-var colorBold = color.New(color.Bold).SprintFunc()
+var colorHeader = colors.HiBlue().SprintFunc()
+var colorFaint = colors.FaintHiBlue().SprintFunc()
+var colorBold = colors.Bold().SprintFunc()
 
 type Response map[string]any
 

--- a/pkg/usb/lockdownd/lockdownd.go
+++ b/pkg/usb/lockdownd/lockdownd.go
@@ -3,14 +3,14 @@ package lockdownd
 import (
 	"fmt"
 
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/pkg/usb"
-	"github.com/fatih/color"
 )
 
 const lockdownPort = 62078
 
-var colorFaint = color.New(color.Faint, color.FgHiBlue).SprintFunc()
-var colorBold = color.New(color.Bold).SprintFunc()
+var colorFaint = colors.FaintHiBlue().SprintFunc()
+var colorBold = colors.Bold().SprintFunc()
 
 type Client struct {
 	*usb.Client

--- a/pkg/usb/mcinstall/mcinstall.go
+++ b/pkg/usb/mcinstall/mcinstall.go
@@ -5,18 +5,18 @@ import (
 	"os"
 
 	"github.com/blacktop/go-plist"
+	"github.com/blacktop/ipsw/internal/colors"
 	"github.com/blacktop/ipsw/pkg/usb"
 	"github.com/blacktop/ipsw/pkg/usb/lockdownd"
-	"github.com/fatih/color"
 )
 
 const (
 	serviceName = "com.apple.mobile.MCInstall"
 )
 
-var colorHeader = color.New(color.FgHiBlue).SprintFunc()
-var colorFaint = color.New(color.Faint, color.FgHiBlue).SprintFunc()
-var colorBold = color.New(color.Bold).SprintFunc()
+var colorHeader = colors.HiBlue().SprintFunc()
+var colorFaint = colors.FaintHiBlue().SprintFunc()
+var colorBold = colors.Bold().SprintFunc()
 
 type Client struct {
 	c *usb.Client

--- a/pkg/usb/usbmuxd.go
+++ b/pkg/usb/usbmuxd.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/blacktop/go-plist"
-	"github.com/fatih/color"
+	"github.com/blacktop/ipsw/internal/colors"
 )
 
 const (
@@ -19,8 +19,8 @@ const (
 	ClientVersionString = "ipsw-usbmux-0.0.1"
 )
 
-var colorFaint = color.New(color.Faint, color.FgHiBlue).SprintFunc()
-var colorBold = color.New(color.Bold).SprintFunc()
+var colorFaint = colors.FaintHiBlue().SprintFunc()
+var colorBold = colors.Bold().SprintFunc()
 
 type Header struct {
 	Length      uint32


### PR DESCRIPTION
Previously, color output was unconditionally controlled by the --no-color flag, overwriting fatih/color's automatic TTY detection. This caused ANSI escape codes to appear in redirected/piped output, violating UNIX conventions.

Changes:
- Add internal/colors package centralizing color handling
- Only override auto-detection when --color or --no-color explicitly set
- Let fatih/color's isatty detection work by default
- Consolidate color constructors to avoid duplication across packages

Closes #971 