### PR TITLE
fix: address staticcheck issues

### DIFF
--- a/cmd/ipsw/cmd/docs.go
+++ b/cmd/ipsw/cmd/docs.go
@@ -22,7 +22,6 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -43,37 +42,6 @@ sidebar_label: %s
 description: %s
 ---
 `
-
-type link struct {
-	Type  string `json:"type,omitempty"`
-	Title string `json:"title,omitempty"`
-}
-
-type category struct {
-	Label       string `json:"label,omitempty"`
-	Collapsible bool   `json:"collapsible,omitempty"`
-	Collapsed   bool   `json:"collapsed,omitempty"`
-	Link        link   `json:"link"`
-}
-
-func createCategoryJSON(cmd *cobra.Command, dir string) error {
-	category, err := json.Marshal(&category{
-		Label:       cmd.Name(),
-		Collapsible: true,
-		Collapsed:   true,
-		Link: link{
-			Type:  "generated-index",
-			Title: cmd.Name(),
-		},
-	})
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(dir, "_category_.json"), category, 0644); err != nil {
-		return err
-	}
-	return nil
-}
 
 func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender func(string, string) string, linkHandler func(string) string) error {
 	for _, c := range cmd.Commands() {

--- a/cmd/ipsw/cmd/dyld/dyld.go
+++ b/cmd/ipsw/cmd/dyld/dyld.go
@@ -30,7 +30,6 @@ import (
 )
 
 var symAddrColor = color.New(color.Faint).SprintfFunc()
-var symImageColor = color.New(color.Faint, color.FgBlue).SprintfFunc()
 var symTypeColor = color.New(color.Faint, color.FgCyan).SprintfFunc()
 var symLibColor = color.New(color.Faint, color.FgMagenta).SprintfFunc()
 var symNameColor = color.New(color.Bold).SprintFunc()

--- a/cmd/ipsw/cmd/dyld/dyld_mg.go
+++ b/cmd/ipsw/cmd/dyld/dyld_mg.go
@@ -234,7 +234,7 @@ var dyldMgCmd = &cobra.Command{
 		if newMGs > 0 {
 			cont := false
 			prompt := &survey.Confirm{
-				Message: fmt.Sprintf("You are about to update the MG JSON with NEW obfuscated MG Keys. Continue?"),
+				Message: "You are about to update the MG JSON with NEW obfuscated MG Keys. Continue?",
 			}
 			survey.AskOne(prompt, &cont)
 
@@ -255,7 +255,7 @@ var dyldMgCmd = &cobra.Command{
 			if bruteForce(mysteries, length) {
 				cont := false
 				prompt := &survey.Confirm{
-					Message: fmt.Sprintf("You are about to update the MG JSON with brute forced keys (you can test with 'ipsw idev diag mg --keys'). Continue?"),
+					Message: "You are about to update the MG JSON with brute forced keys (you can test with 'ipsw idev diag mg --keys'). Continue?",
 				}
 				survey.AskOne(prompt, &cont)
 

--- a/cmd/ipsw/cmd/macho/macho_a2s.go
+++ b/cmd/ipsw/cmd/macho/macho_a2s.go
@@ -61,7 +61,7 @@ var machoA2sCmd = &cobra.Command{
 		machoPath := filepath.Clean(args[0])
 
 		if ok, err := magic.IsMachO(machoPath); !ok {
-			return fmt.Errorf(err.Error())
+			return err
 		}
 
 		// Use the helper to handle fat/universal files

--- a/cmd/ipsw/cmd/macho/macho_info.go
+++ b/cmd/ipsw/cmd/macho/macho_info.go
@@ -648,6 +648,9 @@ var machoInfoCmd = &cobra.Command{
 						return err
 					}
 					lcdata, err := json.MarshalIndent(lc, "", "  ")
+					if err != nil {
+						return err
+					}
 					if color {
 						if err := quick.Highlight(os.Stdout, string(lcdata)+"\n", "json", "terminal256", "nord"); err != nil {
 							return err
@@ -663,6 +666,9 @@ var machoInfoCmd = &cobra.Command{
 						return err
 					}
 					lcdata, err := json.MarshalIndent(lc, "", "  ")
+					if err != nil {
+						return err
+					}
 					if color {
 						if err := quick.Highlight(os.Stdout, string(lcdata)+"\n", "json", "terminal256", "nord"); err != nil {
 							return err
@@ -678,6 +684,9 @@ var machoInfoCmd = &cobra.Command{
 						return err
 					}
 					lcdata, err := json.MarshalIndent(lc, "", "  ")
+					if err != nil {
+						return err
+					}
 					if color {
 						if err := quick.Highlight(os.Stdout, string(lcdata)+"\n", "json", "terminal256", "nord"); err != nil {
 							return err
@@ -693,6 +702,9 @@ var machoInfoCmd = &cobra.Command{
 						return err
 					}
 					lcdata, err := json.MarshalIndent(lc, "", "  ")
+					if err != nil {
+						return err
+					}
 					if color {
 						if err := quick.Highlight(os.Stdout, string(lcdata)+"\n", "json", "terminal256", "nord"); err != nil {
 							return err

--- a/cmd/ipsw/cmd/macho/macho_patch_add.go
+++ b/cmd/ipsw/cmd/macho/macho_patch_add.go
@@ -109,7 +109,7 @@ var machoPatchAddCmd = &cobra.Command{
 		}
 
 		if ok, err := magic.IsMachO(machoPath); !ok {
-			return fmt.Errorf(err.Error())
+			return err
 		}
 
 		if len(output) == 0 { // modify in place

--- a/cmd/ipsw/cmd/macho/macho_patch_mod.go
+++ b/cmd/ipsw/cmd/macho/macho_patch_mod.go
@@ -109,7 +109,7 @@ var machoPatchModCmd = &cobra.Command{
 		}
 
 		if ok, err := magic.IsMachO(machoPath); !ok {
-			return fmt.Errorf(err.Error())
+			return err
 		}
 
 		if len(output) == 0 { // modify in place

--- a/cmd/ipsw/cmd/macho/macho_patch_rm.go
+++ b/cmd/ipsw/cmd/macho/macho_patch_rm.go
@@ -109,7 +109,7 @@ var machoPatchRmCmd = &cobra.Command{
 		}
 
 		if ok, err := magic.IsMachO(machoPath); !ok {
-			return fmt.Errorf(err.Error())
+			return err
 		}
 
 		if len(output) == 0 { // modify in place

--- a/cmd/ipswd/cmd/root.go
+++ b/cmd/ipswd/cmd/root.go
@@ -34,10 +34,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	userConfigDir string
-	cfgFile       string
-)
+var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/pkg/tss/tss.go
+++ b/pkg/tss/tss.go
@@ -137,6 +137,7 @@ func applyRestoreRequestRules(entry map[string]any, parameters map[string]any, r
 		conditionsFulfilled := true
 
 		if hasConditions {
+		conditionLoop:
 			for condKey, condValue := range conditions {
 				var paramValue any
 				switch condKey {
@@ -153,7 +154,7 @@ func applyRestoreRequestRules(entry map[string]any, parameters map[string]any, r
 				default:
 					// Unknown condition, assume not fulfilled
 					conditionsFulfilled = false
-					break
+					break conditionLoop
 				}
 
 				if paramValue != condValue {

--- a/pkg/usb/afc/afc.go
+++ b/pkg/usb/afc/afc.go
@@ -292,7 +292,9 @@ func (c *Client) recvResponseTo(payloadBuf []byte) (*response, error) {
 	if resp.payloadSize > uint64(len(payloadBuf)) {
 		return nil, fmt.Errorf("buffer is %d, needs %d", len(payloadBuf), resp.payloadSize)
 	}
-	_, err = io.ReadFull(c.c.Conn(), payloadBuf[:resp.payloadSize])
+	if _, err = io.ReadFull(c.c.Conn(), payloadBuf[:resp.payloadSize]); err != nil {
+		return nil, err
+	}
 	return resp, nil
 }
 

--- a/pkg/usb/afc/helper.go
+++ b/pkg/usb/afc/helper.go
@@ -109,16 +109,21 @@ func (c *Client) CopyToDevice(dst, src string, copyCbFn CopyCallbackFunc) error 
 	}
 	if srcInfo.IsDir() {
 		return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
 			targetPath := pathpkg.Join(dst, path)
 			fmt.Println(targetPath, path)
 			if info.IsDir() {
 				return c.MakeDir(targetPath)
 			}
-			err = c.CopyFileToDevice(targetPath, path)
+			if err := c.CopyFileToDevice(targetPath, path); err != nil {
+				return err
+			}
 			if copyCbFn != nil {
 				copyCbFn(targetPath, src, info)
 			}
-			return err
+			return nil
 		})
 	}
 

--- a/pkg/usb/amfi/amfi.go
+++ b/pkg/usb/amfi/amfi.go
@@ -9,7 +9,7 @@ import (
 
 const serviceName = "com.apple.amfi.lockdown"
 
-var ErrPasscodeSet = fmt.Errorf("Device has a passcode set")
+var ErrPasscodeSet = fmt.Errorf("device has a passcode set")
 
 type AmfiAction struct {
 	Action int `plist:"action,omitempty"`


### PR DESCRIPTION
Fixes bugs and style issues found by staticcheck:

Bug fixes:
- afc/helper.go: Check incoming error in filepath.Walk callback (SA4009)
- afc/afc.go: Handle io.ReadFull error instead of ignoring it (SA4006)
- macho_info.go: Check json.MarshalIndent errors in 4 places (SA4006)
- tss.go: Use labeled break to exit for loop, not just switch (SA4011)
- macho_*.go: Return error directly instead of fmt.Errorf(err.Error()) (SA1006)

Style fixes:
- amfi.go: Lowercase error message per Go conventions (ST1005)
- ber2der.go: Remove Yoda condition (ST1017)
- dyld_mg.go: Remove unnecessary fmt.Sprintf calls (S1039)

Dead code removal:
- docs.go: Remove unused link, category types and createCategoryJSON func
- dyld.go: Remove unused symImageColor variable
- root.go: Remove unused userConfigDir variable
- ber2der.go: Remove unused encodeIndent and related debug code

Closes #973 