### PR TITLE
feature: build(nix): add flake-based build system with frida and unicorn support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
+fi
+
+dotenv() {
+  if [[ -f .env ]]; then
+    export $(grep -v '^#' .env | xargs)
+  fi
+}
+
+use flake .
+dotenv
+

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,58 @@
+name: Nix
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/**"
+      - ".github/workflows/nix.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/**"
+      - ".github/workflows/nix.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Check flake
+        run: nix flake check --all-systems
+
+  build:
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build ipsw
+        run: nix build .#ipsw --print-build-logs
+
+      - name: Show result
+        run: nix run .#ipsw -- version

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,6 @@ www/docs/static/releases*.json
 # Other
 *.unstripped
 *.bndb
-*.lock
 *.mobileprovision
 *.img
 *.pkg
@@ -91,3 +90,8 @@ cmd/ipsw/cmd/sb/sb_database.go
 cmd/ipsw/cmd/sb/sb_dec.go
 cmd/ipsw/cmd/sb/sb_opts.go
 pkg/sandbox/
+
+/.direnv
+
+# git-hooks.nix
+/.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764915887,
+        "narHash": "sha256-CeBCJ9BMsuzVgn8GVfuSRZ6xeau7szzG0Xn6O/OxP9M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "42e29df35be6ef54091d3a3b4e97056ce0a98ce8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  inputs = {
+    # module system for nix flakes
+    # https://flake.parts
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} (let
+      systems = import inputs.systems;
+      flakeModules.default = import ./nix/flake-module.nix;
+    in {
+      # https://flake.parts/debug.html
+      # debug = true
+
+      # https://nixos.wiki/wiki/NixOS_modules
+      # https://flake.parts/best-practices-for-module-writing.html
+      imports = [
+        flakeModules.default
+        flake-parts.flakeModules.partitions
+      ];
+
+      inherit systems;
+
+      # see https://flake.parts/options/flake-parts-partitions.html
+      partitionedAttrs = {
+        apps = "dev";
+        checks = "dev";
+        devShells = "dev";
+        formatter = "dev";
+      };
+      partitions.dev = {
+        # specifies directory with inputs-only flake.nix
+        extraInputsFlake = ./nix/dev;
+        module = {
+          imports = [./nix/dev];
+        };
+      };
+      # module defining local flake outputs and config
+      # for definition of "local flake" see:
+      # https://flake.parts/define-module-in-separate-file.html#importapply
+      perSystem = {
+        config,
+        lib,
+        ...
+      }: {
+        options = {
+          # used to avoid relative paths with parent references
+          src = lib.mkOption {
+            default = builtins.path {
+              path = ./.;
+              name = "ipsw";
+            };
+          };
+        };
+        config.packages.default = config.packages.ipsw;
+      };
+
+      # exports
+      flake = {
+        inherit flakeModules;
+      };
+    });
+}

--- a/hack/make/frida-deps
+++ b/hack/make/frida-deps
@@ -8,10 +8,15 @@ fi
 
 : ${FRIDA_VERSION:=""}
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+NIX_CONFIG="$REPO_ROOT/nix/ipsw/config.json"
+
 if [[ "${1-}" =~ ^-*h(elp)?$ ]]; then
     echo 'Usage: hack/make/frida-deps
 
 This script downloads and unpacks the latest frida-core-devkits for macOS.
+Also updates nix/ipsw/config.json with frida version and hashes.
 
 '
     exit
@@ -24,12 +29,20 @@ get_version() {
     echo "  [!] Updating to version: $FRIDA_VERSION"
 }
 
-change_version() {
+change_go_version() {
     echo "  [!] Updating version in cmd/ipsw/cmd/frida/frida.go"
     sed -i '' "s/const fridaVersion = \".*\"/const fridaVersion = \"$FRIDA_VERSION\"/" cmd/ipsw/cmd/frida/frida.go
 }
 
-update_frida() {
+# Compute SRI hash for a URL
+compute_sri_hash() {
+    local url="$1"
+    local hash
+    hash=$(nix-prefetch-url "$url" 2>/dev/null)
+    nix hash convert --hash-algo sha256 --to sri "$hash"
+}
+
+update_homebrew() {
     echo "  [!] Updating frida-core-devkit (ARM64)"
     gh release download $FRIDA_VERSION --pattern 'frida-core-devkit-*-macos-arm64.tar.xz' --repo frida/frida --dir /tmp --skip-existing
     gunzip -c /tmp/frida-core-devkit-*-macos-arm64.tar.xz | tar -xf - -C /opt/homebrew/lib libfrida-core.a
@@ -40,11 +53,47 @@ update_frida() {
     gunzip -c /tmp/frida-core-devkit-*-macos-x86_64.tar.xz | tar -xf - -C /usr/local/homebrew/include frida-core.h
 }
 
+update_nix_frida() {
+    echo "  [!] Updating frida in nix/ipsw/config.json"
+
+    local base_url="https://github.com/frida/frida/releases/download/${FRIDA_VERSION}"
+    local arm64_url="${base_url}/frida-core-devkit-${FRIDA_VERSION}-macos-arm64.tar.xz"
+    local x86_64_url="${base_url}/frida-core-devkit-${FRIDA_VERSION}-macos-x86_64.tar.xz"
+
+    echo "  [!] Computing hash for aarch64-darwin..."
+    local arm64_hash
+    arm64_hash=$(compute_sri_hash "$arm64_url")
+
+    echo "  [!] Computing hash for x86_64-darwin..."
+    local x86_64_hash
+    x86_64_hash=$(compute_sri_hash "$x86_64_url")
+
+    local frida_json
+    frida_json=$(jq -n \
+        --arg version "$FRIDA_VERSION" \
+        --arg arm64_url "$arm64_url" \
+        --arg arm64_hash "$arm64_hash" \
+        --arg x86_64_url "$x86_64_url" \
+        --arg x86_64_hash "$x86_64_hash" \
+        '{
+            version: $version,
+            sources: {
+                "aarch64-darwin": { url: $arm64_url, hash: $arm64_hash },
+                "x86_64-darwin": { url: $x86_64_url, hash: $x86_64_hash }
+            }
+        }')
+
+    jq --argjson frida "$frida_json" '.frida = $frida' "$NIX_CONFIG" > "$NIX_CONFIG.tmp"
+    mv "$NIX_CONFIG.tmp" "$NIX_CONFIG"
+    echo "  [!] Updated $NIX_CONFIG"
+}
+
 main() {
     echo "  🚀 Starting..."
     get_version
-    change_version
-    update_frida
+    change_go_version
+    update_homebrew
+    update_nix_frida
     echo "  🎉 Done!"
 }
 

--- a/nix/common/args.nix
+++ b/nix/common/args.nix
@@ -1,0 +1,45 @@
+# common arguments, shared between dev and build
+{lib, ...}: {
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: let
+    inherit (config) frida;
+
+    compileFlags = lib.optionalString (frida.dev-kit != null) "-I${frida.dev-kit}/include";
+    linkFlags = lib.optionalString (frida.dev-kit != null) "-L${frida.dev-kit}/lib -lfrida-core";
+
+    mkTags = tags: ["-tags=${lib.concatStringsSep "," tags}"];
+  in {
+    options = {
+      commonArgs = lib.mkOption {
+        type = lib.types.attrs;
+        default = {
+          buildInputs = with pkgs;
+            [
+              libusb1
+              unicorn
+            ]
+            ++ lib.optionals config.stdenv.hostPlatform.isDarwin [pkgs.apple-sdk_15]
+            ++ lib.optionals (frida.dev-kit != null) [frida.dev-kit];
+
+          env.CGO_ENABLED = 1;
+
+          nativeBuildInputs = with config.toolchain; [
+            clang
+            bintools
+          ];
+
+          CGO_CFLAGS = compileFlags;
+          CGO_CXXFLAGS = compileFlags;
+          CGO_LDFLAGS = linkFlags;
+          GOFLAGS = mkTags [
+            "unicorn"
+            (lib.optionalString (frida.dev-kit != null) "frida")
+          ];
+        };
+      };
+    };
+  };
+}

--- a/nix/common/default.nix
+++ b/nix/common/default.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ./args.nix
+    ./frida-devkit.nix
+    ./toolchain.nix
+  ];
+}

--- a/nix/common/frida-devkit.nix
+++ b/nix/common/frida-devkit.nix
@@ -1,0 +1,62 @@
+# derivation for frida-devkit
+{lib, ...}: {
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: let
+    inherit (config) frida;
+    inherit (pkgs) fetchurl stdenvNoCC;
+
+    platformTag = stdenvNoCC.hostPlatform.system;
+
+    sources = lib.attrByPath ["${platformTag}"] null frida.config.sources;
+  in {
+    # cannot use config.packages because it cannot contain null attrs,
+    # which is the case for frida on unsupported platforms
+    config.frida.dev-kit = lib.mkIf (sources != null) (stdenvNoCC.mkDerivation {
+      pname = "frida-devkit";
+      inherit (frida.config) version;
+
+      src = fetchurl {
+        inherit (sources) url hash;
+      };
+
+      sourceRoot = ".";
+
+      dontBuild = true;
+      dontConfigure = true;
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/include $out/lib
+
+        cp frida-core.h $out/include/
+        cp libfrida-core.a $out/lib/
+
+        mkdir -p $out/lib/pkgconfig
+        cat > $out/lib/pkgconfig/frida-core.pc << EOF
+        prefix=$out
+        includedir=''${prefix}/include
+        libdir=''${prefix}/lib
+
+        Name: frida-core
+        Description: Frida core library
+        Version: ${frida.config.version}
+        Cflags: -I''${includedir}
+        Libs: -L''${libdir} -lfrida-core
+        EOF
+
+        runHook postInstall
+      '';
+
+      meta = with lib; {
+        description = "Frida core devkit - pre-built library for building Frida bindings";
+        homepage = "https://frida.re";
+        license = licenses.lgpl3Plus;
+        platforms = builtins.attrNames frida.config.sources;
+      };
+    });
+  };
+}

--- a/nix/common/toolchain.nix
+++ b/nix/common/toolchain.nix
@@ -1,0 +1,24 @@
+# toolchain configuration, shared between dev and build
+{lib, ...}: {
+  perSystem = {pkgs, ...}: let
+    inherit (pkgs) go_1_25 buildGo125Module;
+    inherit (pkgs.llvmPackages_latest) bintools clang stdenv;
+  in {
+    options = {
+      stdenv = lib.mkOption {
+        default = stdenv;
+      };
+      toolchain = lib.mkOption {
+        type = lib.types.attrs;
+        default = {
+          # bintools is a nix wrapper for llvm binutils, we use it for lld linker
+          inherit bintools clang;
+
+          # use latest go compiler, overriding the nixpkgs default (go_1_24)
+          go = go_1_25;
+          buildGoModule = buildGo125Module.override {inherit stdenv;};
+        };
+      };
+    };
+  };
+}

--- a/nix/config.json
+++ b/nix/config.json
@@ -1,0 +1,17 @@
+{
+  "version": "3.1.643-dev",
+  "vendorHash": "sha256-xAMHqduFjv3XmyoDftRt9UtHnII7wazGUVFFDXI3sm4=",
+  "frida": {
+    "version": "17.2.0",
+    "sources": {
+      "aarch64-darwin": {
+        "url": "https://github.com/frida/frida/releases/download/17.2.0/frida-core-devkit-17.2.0-macos-arm64.tar.xz",
+        "hash": "sha256-0lVUy1bfNQ8aVKEJMky0uv8CCRQN1AbUyRllye5D3So="
+      },
+      "x86_64-darwin": {
+        "url": "https://github.com/frida/frida/releases/download/17.2.0/frida-core-devkit-17.2.0-macos-x86_64.tar.xz",
+        "hash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      }
+    }
+  }
+}

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -1,0 +1,32 @@
+# configuration options (version, vendorHash, frida)
+{lib, ...}: let
+  # config.json contains:
+  # - current ipsw version
+  # - vendorHash (must be updated upon go deps update)
+  # - pinned frida versions for supported platforms
+  cfg = builtins.fromJSON (builtins.readFile ./config.json);
+in {
+  perSystem = {
+    options = {
+      version = lib.mkOption {
+        default = cfg.version;
+      };
+      vendorHash = lib.mkOption {
+        default = cfg.vendorHash;
+      };
+      frida = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            config = lib.mkOption {
+              default = cfg.frida;
+            };
+            dev-kit = lib.mkOption {
+              type = lib.types.nullOr lib.types.package;
+              default = null;
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/dev/default.nix
+++ b/nix/dev/default.nix
@@ -1,0 +1,10 @@
+{inputs, ...}: {
+  imports = [
+    inputs.git-hooks.flakeModule
+    ../common
+    ./formatter.nix
+    ./go-tools.nix
+    ./pre-commit.nix
+    ./shell.nix
+  ];
+}

--- a/nix/dev/flake.lock
+++ b/nix/dev/flake.lock
@@ -1,0 +1,87 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763988335,
+        "narHash": "sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh+M4Qc=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "50b9238891e388c9fdc6a5c49e49c42533a1b5ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764915887,
+        "narHash": "sha256-CeBCJ9BMsuzVgn8GVfuSRZ6xeau7szzG0Xn6O/OxP9M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "42e29df35be6ef54091d3a3b4e97056ce0a98ce8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/dev/flake.nix
+++ b/nix/dev/flake.nix
@@ -1,0 +1,23 @@
+{
+  # see https://flake.parts/options/flake-parts-partitions.html
+  description = "Dev dependencies inputs flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://pre-commit-hooks.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "pre-commit-hooks.cachix.org-1:Pkk3Panw5AW24TOv6kz3PvLhlH8puAsJTBbOPmBo7Rc="
+    ];
+  };
+
+  outputs = _: {};
+}

--- a/nix/dev/formatter.nix
+++ b/nix/dev/formatter.nix
@@ -1,0 +1,14 @@
+{
+  perSystem = {
+    pkgs,
+    config,
+    ...
+  }: {
+    formatter = pkgs.writeShellScriptBin "fmt-all" ''
+      ${pkgs.alejandra}/bin/alejandra .
+
+      echo "Formatting Go files..."
+      ${config.toolchain.go}/bin/go fmt ./...
+    '';
+  };
+}

--- a/nix/dev/go-tools.nix
+++ b/nix/dev/go-tools.nix
@@ -1,0 +1,30 @@
+# overrides for nixpkgs.go-tools (a.k.a. https://staticcheck.dev)
+# to build it with go_1_25 (currently built with go_1_24 by default)
+{lib, ...}: {
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: let
+    inherit (config.toolchain) go;
+  in {
+    packages.go-tools =
+      (pkgs.go-tools.override {
+        inherit (config.toolchain) buildGoModule;
+      }).overrideAttrs (old: {
+        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [pkgs.makeWrapper];
+
+        # allow runtime reference to go (needed for wrapper)
+        disallowedReferences = [];
+
+        postFixup = ''
+          wrapProgram $out/bin/staticcheck \
+            --prefix PATH : ${lib.makeBinPath [go]}
+        '';
+
+        enableParallelBuilding = true;
+        NIX_ENFORCE_NO_NATIVE = 0;
+        doCheck = false;
+      });
+  };
+}

--- a/nix/dev/pre-commit.nix
+++ b/nix/dev/pre-commit.nix
@@ -1,0 +1,62 @@
+{
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: {
+    pre-commit = {
+      check.enable = true;
+
+      settings.hooks = {
+        # go linting
+
+        # TODO: `staticcheck` takes time to run and might not provide best `nix develop`
+        # activation experience. either re-enable after fixing codebase issues
+        # (U1000, SA4009, etc.), or remove from hooks and use manually as
+        # `staticcheck ./...` from active `nix develop` shell
+
+        # staticcheck = {
+        #   enable = true;
+        #   package = config.packages.go-tools;
+        # };
+
+        # markdown linting
+        # TODO: enable and fix the issues
+        # markdownlint.enable = true;
+
+        # nix code linting
+        deadnix.enable = true;
+        nil.enable = true;
+        alejandra.enable = true;
+        statix.enable = true;
+
+        # spell checking
+        # TODO: enable, filtering out go files, as it catches some legitimate stuff like "udid".
+        # alternative would be literal exclusion list if supported by the tool
+
+        # typos.enable = true;
+      };
+    };
+
+    # hooks installer
+    # NOTE: updates to this file are not immediately picked up, remove symlink first:
+    # ```sh
+    # rm .pre-commit-config.yaml && nix run .#install-hooks
+    # ```
+    #
+    # if using nix-direnv, changes to ./nix/dev require refreshing direnv cache:
+    # ```sh
+    # direnv reload
+    # ```
+    # direnv is not installed by this flake, install it with `nix profile add nixpkgs#direnv`
+
+    apps.install-hooks = {
+      type = "app";
+      program = toString (pkgs.writeShellScript "install-hooks" ''
+        ${config.pre-commit.installationScript}
+        echo "Pre-commit hooks installed!"
+      '');
+      meta.description = "install pre-commit hooks";
+    };
+  };
+}

--- a/nix/dev/shell.nix
+++ b/nix/dev/shell.nix
@@ -1,0 +1,23 @@
+# shell for developer mode (`nix develop`)
+# recommended: automatic activation via nix-direnv (https://github.com/nix-community/nix-direnv)
+# ```sh
+# direnv allow .
+# ```
+{
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: let
+    inherit (config) pre-commit;
+  in {
+    devShells.default = pkgs.mkShell.override {inherit (config) stdenv;} ({
+        packages = pre-commit.settings.enabledPackages;
+
+        shellHook = ''
+          ${pre-commit.installationScript}
+        '';
+      }
+      // config.commonArgs);
+  };
+}

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -1,0 +1,51 @@
+# main flake module which builds `ipsw`
+{lib, ...}: {
+  imports = [
+    ./config.nix
+    ./common
+  ];
+
+  perSystem = {config, ...}: let
+    inherit
+      (config.commonArgs)
+      CGO_CFLAGS
+      CGO_CXXFLAGS
+      CGO_LDFLAGS
+      ;
+
+    # config.commonArgs is an attrset, not a derivation, so overrideAttrs cannot be used.
+    # we remove the attrs we want to override, then re-add them extended with compiler flags
+    commonArgsStripped = builtins.removeAttrs config.commonArgs ["CGO_CFLAGS" "CGO_CXXFLAGS" "CGO_LDFLAGS"];
+
+    compileFlags = "-O3 -mcpu=native -flto=thin -Wall -pipe";
+    linkFlags = "-flto=thin -Wl,-dead_strip";
+
+    concatFlags = flags: lib.concatStringsSep " " flags;
+  in {
+    packages.ipsw = config.toolchain.buildGoModule (commonArgsStripped
+      // {
+        pname = "ipsw";
+        inherit (config) src version vendorHash;
+
+        ldflags = [
+          "-s"
+          "-w"
+          "-X github.com/blacktop/ipsw/cmd/ipsw/cmd.AppVersion=${config.version}"
+        ];
+
+        subPackages = ["./cmd/ipsw"];
+
+        enableParallelBuilding = true;
+
+        hardeningDisable = ["all"];
+        NIX_ENFORCE_NO_NATIVE = 0;
+
+        CGO_CFLAGS = concatFlags [CGO_CFLAGS compileFlags];
+        CGO_CXXFLAGS = concatFlags [CGO_CXXFLAGS compileFlags];
+        CGO_LDFLAGS = concatFlags [CGO_LDFLAGS linkFlags];
+
+        # TODO: fine-grained disabling of tests which require network or hardware
+        doCheck = false;
+      });
+  };
+}


### PR DESCRIPTION
Hi, 

this is something I use myself and find it great to have. 

It's opinionated but generally follows modern nix ecosystem' best practices, e.g. using http://flake.parts - great framework for writing modularized nix flakes.

So if you are interested to get this upstreamed, I'd be glad to discuss.


### details

Add comprehensive Nix flake infrastructure for reproducible builds:

Flake structure:
- flake-parts with partitioned dev tools (git-hooks in separate partition)
- Centralized config in nix/config.json for version, vendorHash, frida sources
- Reusable flake module exported for downstream consumption

Build features:
- Go 1.25 toolchain with LLVM/Clang for CGO
- Frida devkit integration with automatic platform detection (macOS arm64/x86_64)
- Unicorn CPU emulator support enabled by default
- Optimized CGO flags (-O3, -mcpu=native, -flto=thin)

Development environment:
- direnv integration via .envrc for automatic shell activation
- Pre-commit hooks: alejandra, deadnix, nil, statix (nix linting)
- Combined formatter for Nix (alejandra) and Go (go fmt)
- staticcheck wrapper with Go in PATH (currently disabled pending codebase fixes)

CI:
- GitHub Actions workflow with DeterminateSystems nix-installer and magic-nix-cache
- Runs flake check on all systems, builds on ubuntu and macos

Tooling updates:
- hack/make/frida-deps now computes SRI hashes and updates nix/config.json