### PR TITLE
fix: check fat macho handle when reading extractor version

### DIFF
--- a/pkg/dyld/split.go
+++ b/pkg/dyld/split.go
@@ -150,10 +150,12 @@ func Split(dyldSharedCachePath, destinationPath, xcodePath string, xcodeCache bo
 			return fmt.Errorf("failed to open %s: %v", dscExtractor.Libname, err)
 		}
 		extVer := "1040.2.2.0.0"
-		if fat.Arches[0].SourceVersion() != nil {
-			extVer = fat.Arches[0].SourceVersion().Version.String()
+		if fat != nil {
+			if fat.Arches[0].SourceVersion() != nil {
+				extVer = fat.Arches[0].SourceVersion().Version.String()
+			}
+			fat.Close()
 		}
-		fat.Close()
 		// get XCodeVersion
 		xcodeContentPath := strings.TrimSuffix(dscExtractor.Libname, "/Developer/Platforms/iPhoneOS.platform/usr/lib/dsc_extractor.bundle")
 		xcodeContentPath = filepath.Join(xcodeContentPath, "Info.plist")


### PR DESCRIPTION
This is a trivial fix for https://github.com/blacktop/ipsw/issues/978

However, in this case, the non-FAT extractor bundles will always get the default version `"1040.2.2.0.0"`