### PR TITLE
compat: [restored] BigSur support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,6 +172,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/ink-splatters/darwin-sectrust-compat v0.1.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -534,6 +534,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/ink-splatters/darwin-sectrust-compat v0.1.3 h1:Wwh4egVoG8FP9iFQu3Ke7R0HgzQSksfIG2H+cQrZGfk=
+github.com/ink-splatters/darwin-sectrust-compat v0.1.3/go.mod h1:51aVN/ONmlSzKJfM8hXQ3plDDHZuXIEnJL9HCoSeEaY=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/hack/goreleaser/darwin-compat.yml
+++ b/hack/goreleaser/darwin-compat.yml
@@ -1,0 +1,58 @@
+# Builds for arm64 darwin in macOS Big Sur compatibility mode
+# See: https://github.com/ink-splatters/darwin-sectrust-compat
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - ./hack/make/completions
+    - ./hack/make/manpages
+
+builds:
+  - id: darwin_arm64_extras_compat
+    main: ./cmd/ipsw
+    binary: ipsw
+    env:
+      - CGO_ENABLED=1
+      - CGO_LDFLAGS=-L/opt/homebrew/lib
+      - CGO_CFLAGS=-I/opt/homebrew/include
+      - PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    tags:
+      - libusb
+      - unicorn
+      - sectrust_compat
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/blacktop/ipsw/cmd/ipsw/cmd.AppVersion={{.Version}}
+      - -X github.com/blacktop/ipsw/cmd/ipsw/cmd.AppBuildCommit={{.Commit}}
+
+archives:
+  - id: darwin_arm64_extras_compat_archive
+    builds:
+      - darwin_arm64_extras_compat
+    name_template: "{{ .ProjectName }}_{{ .Version }}_macOS_arm64_extras_compat"
+    replacements:
+      darwin: macOS
+      ios: iOS
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README.md
+      - LICENSE
+      - completions/*
+      - manpages/*
+    wrap_in_directory: true
+
+checksum:
+  name_template: "checksums.darwin_arm64_extras_compat.txt"
+
+sboms:
+  - artifacts: archive

--- a/internal/utils/macos_sectrust_compat.go
+++ b/internal/utils/macos_sectrust_compat.go
@@ -1,0 +1,16 @@
+// go 1.25 dropped macOS Big Sur support by introducing dependency on macOS 12+ API,
+// so neither toolchain nor software built with it can be run on Big Sur
+//
+// Reference: https://github.com/golang/go/blob/ea603eea37f1030cfeecbe03ec7660fbc0da7819/src/crypto/x509/internal/macos/security.s#L26
+//
+// This shim provides _SecTrustCopyCertificateChain symbol required by go 1.25 runtime
+// to mitigate this.
+//
+// NOTE: unless macOS SDK 10.14 - 11.x is detected, this shim is DISABLED by default.
+// To enable regardless of macOS SDK version, pass `sectrust_compat` build tag.
+
+package utils
+
+import (
+	_ "github.com/ink-splatters/darwin-sectrust-compat"
+)


### PR DESCRIPTION
Go 1.25 dropped Big Sur support by introducing dependency on [macOS 12+ only API](https://github.com/golang/go/blob/ea603eea37f1030cfeecbe03ec7660fbc0da7819/src/crypto/x509/internal/macos/security.s#L26)

This PR restores the support using compatibility shim which provides the missing symbol  (`_SecTrustCopyCertificateChain`).

The implementation is based on deprecated but stable API, accounting for side effects produced by original API from macOS `26.2 25C56`

For details, refer to:

- Implementation: https://github.com/ink-splatters/darwin-sectrust-compat (feel free to fetch it for any purposes beyond this PR).
- https://github.com/ink-splatters/darwin-sectrust-compat/blob/9157c5bdeaa787c7e01c9a2147f0b2f6cfa8a98d/darwin_sectrust_compat.c#L36
- https://gist.github.com/ink-splatters/af142fd07c686aed0c5cf97f84a619ee


The shim is disabled by default when modern macOS SDK is in use and can be explicitly enabled via build tag `sectrust_compat`

A goreleaser config was created to produce Big Sur compatible builds by supplying that tag:
    `hack/goreleaser/darwin-compat.yml`