### PR TITLE
fix(kernel/kmutil): handle Mach-O and IMG4 kernel collections

### DIFF
--- a/cmd/ipsw/cmd/kernel/kernel_kmutil_create.go
+++ b/cmd/ipsw/cmd/kernel/kernel_kmutil_create.go
@@ -22,16 +22,12 @@ THE SOFTWARE.
 package kernel
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/apex/log"
-	"github.com/blacktop/go-macho"
 	"github.com/blacktop/go-macho/types"
-	"github.com/blacktop/ipsw/internal/magic"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/kernelcache"
 	"github.com/spf13/cobra"
@@ -76,32 +72,11 @@ var createCmd = &cobra.Command{
 			return fmt.Errorf("file %s does not exist", kcpath)
 		}
 
-		var m *macho.File
-
-		isImg4, err := magic.IsImg4(kcpath)
+		m, err := openKernelCollection(kcpath)
 		if err != nil {
-			return fmt.Errorf("failed to check if kernelcache is img4: %w", err)
+			return err
 		}
-
-		if isImg4 {
-			log.Info("Decompressing KernelManagement kernelcache")
-			data, err := kernelcache.DecompressKernelManagementData(kcpath)
-			if err != nil {
-				return fmt.Errorf("failed to decompress kernelcache (kernel management data): %v", err)
-			}
-			m, err = macho.NewFile(bytes.NewReader(data))
-			if err != nil {
-				return fmt.Errorf("failed to parse kernelcache (kernel management data): %v", err)
-			}
-			defer m.Close()
-		} else {
-			log.Info("Parsing KernelManagement kernelcache")
-			m, err = macho.Open(kcpath)
-			if err != nil {
-				return fmt.Errorf("failed to parse kernelcache MachO: %v", err)
-			}
-			defer m.Close()
-		}
+		defer m.Close()
 
 		if m.FileTOC.FileHeader.Type != types.MH_FILESET {
 			return fmt.Errorf("kernelcache type is not MH_FILESET (kext collection)")

--- a/cmd/ipsw/cmd/kernel/kernel_kmutil_inspect.go
+++ b/cmd/ipsw/cmd/kernel/kernel_kmutil_inspect.go
@@ -22,15 +22,11 @@ THE SOFTWARE.
 package kernel
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/apex/log"
-	"github.com/blacktop/go-macho"
 	"github.com/blacktop/go-macho/types"
-	"github.com/blacktop/ipsw/internal/magic"
 	"github.com/blacktop/ipsw/internal/utils"
 	"github.com/blacktop/ipsw/pkg/kernelcache"
 	"github.com/spf13/cobra"
@@ -99,32 +95,11 @@ var inspectCmd = &cobra.Command{
 			return fmt.Errorf("file %s does not exist", kcpath)
 		}
 
-		var m *macho.File
-
-		isImg4, err := magic.IsImg4(kcpath)
+		m, err := openKernelCollection(kcpath)
 		if err != nil {
-			return fmt.Errorf("failed to check if kernelcache is img4: %w", err)
+			return err
 		}
-
-		if isImg4 {
-			log.Info("Decompressing KernelManagement kernelcache")
-			data, err := kernelcache.DecompressKernelManagementData(kcpath)
-			if err != nil {
-				return fmt.Errorf("failed to decompress kernelcache (kernel management data): %v", err)
-			}
-			m, err = macho.NewFile(bytes.NewReader(data))
-			if err != nil {
-				return fmt.Errorf("failed to parse kernelcache (kernel management data): %v", err)
-			}
-			defer m.Close()
-		} else {
-			log.Info("Parsing KernelManagement kernelcache")
-			m, err = macho.Open(kcpath)
-			if err != nil {
-				return fmt.Errorf("failed to parse kernelcache MachO: %v", err)
-			}
-			defer m.Close()
-		}
+		defer m.Close()
 
 		if m.FileTOC.FileHeader.Type != types.MH_FILESET {
 			return fmt.Errorf("kernelcache type is not MH_FILESET (kext collection)")

--- a/cmd/ipsw/cmd/kernel/kernel_kmutil_loader.go
+++ b/cmd/ipsw/cmd/kernel/kernel_kmutil_loader.go
@@ -1,0 +1,68 @@
+/*
+Copyright © 2025 blacktop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package kernel
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/apex/log"
+	"github.com/blacktop/go-macho"
+	"github.com/blacktop/ipsw/internal/magic"
+	"github.com/blacktop/ipsw/pkg/kernelcache"
+)
+
+func openKernelCollection(path string) (*macho.File, error) {
+	isMachO, err := magic.IsMachO(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect kernelcache Mach-O format: %w", err)
+	}
+	if isMachO {
+		log.Info("Parsing KernelManagement kernelcache")
+		m, err := macho.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse kernelcache MachO: %v", err)
+		}
+		return m, nil
+	}
+
+	isImg4, err := magic.IsImg4(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect kernelcache IMG4 format: %w", err)
+	}
+	if !isImg4 {
+		return nil, fmt.Errorf("unsupported kernelcache format: expected Mach-O or IMG4")
+	}
+
+	log.Info("Decompressing KernelManagement kernelcache")
+	data, err := kernelcache.DecompressKernelManagementData(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompress kernelcache (kernel management data): %v", err)
+	}
+
+	m, err := macho.NewFile(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kernelcache (kernel management data): %v", err)
+	}
+
+	return m, nil
+}

--- a/cmd/ipsw/cmd/kernel/kernel_kmutil_loader_test.go
+++ b/cmd/ipsw/cmd/kernel/kernel_kmutil_loader_test.go
@@ -1,0 +1,55 @@
+package kernel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenKernelCollectionPrefersMachOPath(t *testing.T) {
+	// Mach-O 64-bit magic (little-endian): 0xfeedfacf.
+	// The file is intentionally truncated so parse fails after detection.
+	path := filepath.Join(t.TempDir(), "BootKernelExtensions.kc")
+	if err := os.WriteFile(path, []byte{0xcf, 0xfa, 0xed, 0xfe}, 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	_, err := openKernelCollection(path)
+	if err == nil {
+		t.Fatal("expected parse error for truncated Mach-O file")
+	}
+	if !strings.Contains(err.Error(), "failed to parse kernelcache MachO") {
+		t.Fatalf("expected Mach-O parse path error, got: %v", err)
+	}
+}
+
+func TestOpenKernelCollectionUsesImg4PathByExtension(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kernelcache.img4")
+	if err := os.WriteFile(path, []byte("not a valid img4 payload"), 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	_, err := openKernelCollection(path)
+	if err == nil {
+		t.Fatal("expected decompression error for invalid img4 payload")
+	}
+	if !strings.Contains(err.Error(), "failed to decompress kernelcache (kernel management data)") {
+		t.Fatalf("expected IMG4 decompression path error, got: %v", err)
+	}
+}
+
+func TestOpenKernelCollectionRejectsUnknownFormat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kernelcache.bin")
+	if err := os.WriteFile(path, []byte("random data"), 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	_, err := openKernelCollection(path)
+	if err == nil {
+		t.Fatal("expected format detection error")
+	}
+	if !strings.Contains(err.Error(), "failed to detect kernelcache IMG4 format") {
+		t.Fatalf("expected IMG4 detection error for unknown format, got: %v", err)
+	}
+}


### PR DESCRIPTION
On systems where `GetKernelCollectionPath()` returns a Mach-O `.kc` (for example `x86_64`), commands now parse Mach-O first instead of failing early on IMG4 ASN.1 detection, while preserving the existing IMG4 flow for actual IMG4 inputs.

## Summary
- add a shared kernel collection loader for `kmutil` commands
- detect Mach-O first and only check IMG4 as fallback
- reuse this loader in `kernel kmutil inspect` and `kernel kmutil create`
- remove duplicated format-detection/opening logic that existed in both commands, so behavior stays consistent
- add tests to lock in Mach-O-first behavior and IMG4 fallback

Related #1081.
