### PR TITLE
fix(mount): remove original AEA DMG after decrypting

### DIFF
--- a/internal/commands/mount/mount.go
+++ b/internal/commands/mount/mount.go
@@ -142,8 +142,9 @@ func DmgInIPSW(path, typ string, cfg *Config) (*Context, error) {
 	}
 
 	if filepath.Ext(extractedDMG) == ".aea" {
+		encryptedDMG := extractedDMG
 		defer func() {
-			_ = os.Remove(extractedDMG) // remove the encrypted AEA DMG after decrypting and mounting
+			_ = os.Remove(encryptedDMG) // remove the original encrypted AEA DMG after decrypting and mounting
 		}()
 		extractedDMG, err = aea.Decrypt(&aea.DecryptConfig{
 			Input:    extractedDMG,


### PR DESCRIPTION
## Summary

`ipsw mount sys` leaks the original `*.dmg.aea` temporary extracted from an IPSW.

This happens here:

https://github.com/blacktop/ipsw/blob/c902158f3f0d5211379eb74b116fbef6f8598daf/internal/commands/mount/mount.go#L144-L158

The deferred cleanup closes over `extractedDMG`, but that variable is then reassigned to the decrypted `.dmg` path. When the `defer` runs, it removes the decrypted `DMG` path instead of the original `.dmg.aea`, leaving the encrypted `AEA` file behind.

This is likely not an issue for most users, since the output would be removed when temporaries are garbage collected. However, in our case, where we process many artifacts sequentially on a disk-restricted runner, it can quickly lead to running out of disk space.

## Testing

`ipsw mount sys` on any IPSW that contains `AEA`-encrypted `DMG`s. This is easier to observe with controlled temporary directories (`TMPDIR` env var).

## AI Assistance

none.
