### PR TITLE
feat(class-dump): stable diff-friendly headers and per-path output for DSC

### DIFF
--- a/cmd/ipsw/cmd/class_dump.go
+++ b/cmd/ipsw/cmd/class_dump.go
@@ -244,7 +244,11 @@ var classDumpCmd = &cobra.Command{
 					return fmt.Errorf("failed to parse MachO from dylib '%s': %v", filepath.Base(img.Name), err)
 				}
 
-				conf.Name = filepath.Base(img.Name)
+				if viper.GetBool("class-dump.headers") {
+					conf.Name = img.Name
+				} else {
+					conf.Name = filepath.Base(img.Name)
+				}
 
 				o, err = mcmd.NewObjC(m, f, &conf)
 				if err != nil {

--- a/internal/commands/macho/objc.go
+++ b/internal/commands/macho/objc.go
@@ -54,6 +54,24 @@ type Imports struct {
 	Protos  []string
 }
 
+func dedupeKeepLastByKey[T any](items []T, key func(T) string) []T {
+	if len(items) < 2 {
+		return items
+	}
+	seen := make(map[string]struct{}, len(items))
+	out := make([]T, 0, len(items))
+	for i := len(items) - 1; i >= 0; i-- {
+		k := key(items[i])
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, items[i])
+	}
+	slices.Reverse(out)
+	return out
+}
+
 func (i *Imports) uniq(foundation map[string][]string) {
 	slices.Sort(i.Imports)
 	slices.Sort(i.Locals)
@@ -468,22 +486,25 @@ func (o *ObjC) Headers() error {
 			return cmp.Compare(a.Name, b.Name)
 		})
 		for _, class := range classes {
-			var props []string
-			var setters []string
-			for _, prop := range class.Props {
-				props = append(props, prop.Name)
-				setters = append(setters, "set"+strings.ToUpper(prop.Name[:1])+prop.Name[1:]+":")
-			}
-			slices.Sort(props)
-			slices.Sort(setters)
-			// remove ivars that are properties
-			class.Ivars = slices.DeleteFunc(class.Ivars, func(i objc.Ivar) bool {
-				// return slices.Contains(props, i.Name) || slices.Contains(props, strings.TrimPrefix(i.Name, "_")) TODO: use this instead
-				return slices.Contains(props, strings.TrimPrefix(i.Name, "_"))
+			class.Ivars = dedupeKeepLastByKey(class.Ivars, func(ivar objc.Ivar) string { return ivar.Name })
+			class.Props = dedupeKeepLastByKey(class.Props, func(prop objc.Property) string { return prop.Name })
+			class.ClassMethods = dedupeKeepLastByKey(class.ClassMethods, func(method objc.Method) string { return method.Name })
+			class.InstanceMethods = dedupeKeepLastByKey(class.InstanceMethods, func(method objc.Method) string { return method.Name })
+			class.Protocols = dedupeKeepLastByKey(class.Protocols, func(proto objc.Protocol) string { return proto.Name })
+			slices.SortStableFunc(class.Ivars, func(a, b objc.Ivar) int {
+				return cmp.Compare(a.Name, b.Name)
 			})
-			// remove methods that are property getter/setter
-			class.InstanceMethods = slices.DeleteFunc(class.InstanceMethods, func(m objc.Method) bool {
-				return slices.Contains(props, m.Name) || slices.Contains(setters, m.Name)
+			slices.SortStableFunc(class.Props, func(a, b objc.Property) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+			slices.SortStableFunc(class.ClassMethods, func(a, b objc.Method) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+			slices.SortStableFunc(class.InstanceMethods, func(a, b objc.Method) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+			slices.SortStableFunc(class.Protocols, func(a, b objc.Protocol) int {
+				return cmp.Compare(a.Name, b.Name)
 			})
 			fname := filepath.Join(o.conf.Output, o.conf.Name, class.Name+".h")
 			if err := writeHeader(&headerInfo{
@@ -518,20 +539,29 @@ func (o *ObjC) Headers() error {
 				}
 			}
 			if _, ok := seen[proto.Ptr]; !ok { // prevent displaying duplicates
-				var props []string
-				var setters []string
-				for _, prop := range proto.InstanceProperties {
-					props = append(props, prop.Name)
-					setters = append(setters, "set"+strings.ToUpper(prop.Name[:1])+prop.Name[1:]+":")
-				}
-				slices.Sort(props)
-				slices.Sort(setters)
-				// remove methods that are property getter/setter
-				proto.InstanceMethods = slices.DeleteFunc(proto.InstanceMethods, func(m objc.Method) bool {
-					return slices.Contains(props, m.Name) || slices.Contains(setters, m.Name)
+				proto.ClassMethods = dedupeKeepLastByKey(proto.ClassMethods, func(method objc.Method) string { return method.Name })
+				proto.InstanceMethods = dedupeKeepLastByKey(proto.InstanceMethods, func(method objc.Method) string { return method.Name })
+				proto.ClassProperties = dedupeKeepLastByKey(proto.ClassProperties, func(prop objc.Property) string { return prop.Name })
+				proto.InstanceProperties = dedupeKeepLastByKey(proto.InstanceProperties, func(prop objc.Property) string { return prop.Name })
+				proto.OptionalClassMethods = dedupeKeepLastByKey(proto.OptionalClassMethods, func(method objc.Method) string { return method.Name })
+				proto.OptionalInstanceMethods = dedupeKeepLastByKey(proto.OptionalInstanceMethods, func(method objc.Method) string { return method.Name })
+				slices.SortStableFunc(proto.ClassMethods, func(a, b objc.Method) int {
+					return cmp.Compare(a.Name, b.Name)
 				})
-				proto.OptionalInstanceMethods = slices.DeleteFunc(proto.OptionalInstanceMethods, func(m objc.Method) bool {
-					return slices.Contains(props, m.Name) || slices.Contains(setters, m.Name)
+				slices.SortStableFunc(proto.InstanceMethods, func(a, b objc.Method) int {
+					return cmp.Compare(a.Name, b.Name)
+				})
+				slices.SortStableFunc(proto.ClassProperties, func(a, b objc.Property) int {
+					return cmp.Compare(a.Name, b.Name)
+				})
+				slices.SortStableFunc(proto.InstanceProperties, func(a, b objc.Property) int {
+					return cmp.Compare(a.Name, b.Name)
+				})
+				slices.SortStableFunc(proto.OptionalClassMethods, func(a, b objc.Method) int {
+					return cmp.Compare(a.Name, b.Name)
+				})
+				slices.SortStableFunc(proto.OptionalInstanceMethods, func(a, b objc.Method) int {
+					return cmp.Compare(a.Name, b.Name)
 				})
 				fname := filepath.Join(o.conf.Output, o.conf.Name, proto.Name+"-Protocol.h")
 				if err := writeHeader(&headerInfo{
@@ -571,6 +601,22 @@ func (o *ObjC) Headers() error {
 			} else {
 				name = cat.Name
 			}
+			cat.ClassMethods = dedupeKeepLastByKey(cat.ClassMethods, func(method objc.Method) string { return method.Name })
+			cat.InstanceMethods = dedupeKeepLastByKey(cat.InstanceMethods, func(method objc.Method) string { return method.Name })
+			cat.Properties = dedupeKeepLastByKey(cat.Properties, func(prop objc.Property) string { return prop.Name })
+			cat.Protocols = dedupeKeepLastByKey(cat.Protocols, func(proto objc.Protocol) string { return proto.Name })
+			slices.SortStableFunc(cat.ClassMethods, func(a, b objc.Method) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+			slices.SortStableFunc(cat.InstanceMethods, func(a, b objc.Method) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+			slices.SortStableFunc(cat.Properties, func(a, b objc.Property) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+			slices.SortStableFunc(cat.Protocols, func(a, b objc.Protocol) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
 			if err := writeHeader(&headerInfo{
 				FileName:      fname,
 				IpswVersion:   o.conf.IpswVersion,
@@ -587,12 +633,10 @@ func (o *ObjC) Headers() error {
 
 		/* generate umbrella header */
 		if len(headers) > 0 {
-			var umbrella string
-			if slices.Contains(headers, o.conf.Name+".h") {
-				umbrella = o.conf.Name + "-Umbrella"
-			} else {
-				umbrella = o.conf.Name
-			}
+			var umbrella = o.conf.Name + "-Umbrella"
+			slices.SortStableFunc(headers, func(a, b string) int {
+				return cmp.Compare(a, b)
+			})
 
 			for i, header := range headers {
 				headers[i] = "#import \"" + header + "\""
@@ -844,7 +888,7 @@ func writeHeader(hdr *headerInfo) error {
 			"//\n"+
 			"//    - LC_BUILD_VERSION:  %s\n"+
 			"//    - LC_SOURCE_VERSION: %s\n"+
-			"//\n"+
+			"//\n\n"+
 			"#ifndef %s_h\n"+
 			"#define %s_h\n",
 		hdr.IpswVersion,

--- a/internal/commands/macho/objc.go
+++ b/internal/commands/macho/objc.go
@@ -438,9 +438,38 @@ func (o *ObjC) Headers() error {
 			return nil
 		}
 
-		if id := m.DylibID(); id != nil {
-			o.conf.Name = filepath.Base(id.Name)
+		binaryName := filepath.Base(o.conf.Name)
+		frameworkRelPath := binaryName
+		// safeRelPath sanitizes a candidate path for joining under o.conf.Output.
+		// Returns binaryName as a fallback if the input would escape the output
+		// directory (e.g. via ".." segments, absolute paths, or symlink-style
+		// constructs) or is otherwise non-local.
+		safeRelPath := func(p string) string {
+			cleaned := filepath.Clean(p)
+			if filepath.IsAbs(cleaned) {
+				cleaned = strings.TrimPrefix(cleaned, string(filepath.Separator))
+			}
+			if cleaned == "" || cleaned == "." || !filepath.IsLocal(cleaned) {
+				return binaryName
+			}
+			return cleaned
 		}
+		if id := m.DylibID(); id != nil {
+			binaryName = filepath.Base(id.Name)
+			if o.cache != nil {
+				if filepath.IsAbs(id.Name) {
+					frameworkRelPath = safeRelPath(id.Name)
+				} else {
+					frameworkRelPath = safeRelPath(o.conf.Name)
+				}
+			} else {
+				frameworkRelPath = binaryName
+			}
+		} else if o.cache != nil {
+			frameworkRelPath = safeRelPath(o.conf.Name)
+		}
+		o.conf.Name = binaryName
+		frameworkDir := filepath.Join(o.conf.Output, frameworkRelPath)
 		var buildVersions []string
 		if bvers := m.GetLoadsByName("LC_BUILD_VERSION"); len(bvers) > 0 {
 			for _, bv := range bvers {
@@ -485,7 +514,7 @@ func (o *ObjC) Headers() error {
 			class.InstanceMethods = slices.DeleteFunc(class.InstanceMethods, func(m objc.Method) bool {
 				return slices.Contains(props, m.Name) || slices.Contains(setters, m.Name)
 			})
-			fname := filepath.Join(o.conf.Output, o.conf.Name, class.Name+".h")
+			fname := filepath.Join(frameworkDir, class.Name+".h")
 			if err := writeHeader(&headerInfo{
 				FileName:      fname,
 				IpswVersion:   o.conf.IpswVersion,
@@ -512,7 +541,7 @@ func (o *ObjC) Headers() error {
 		})
 		seen := make(map[uint64]bool)
 		for _, proto := range protos {
-			if !slices.Contains(baseFrameworks, o.conf.Name) {
+			if !slices.Contains(baseFrameworks, binaryName) {
 				if _, found := slices.BinarySearch(o.baseFWs["protocols"], proto.Name); found {
 					continue // skip Foundation protocols
 				}
@@ -533,7 +562,7 @@ func (o *ObjC) Headers() error {
 				proto.OptionalInstanceMethods = slices.DeleteFunc(proto.OptionalInstanceMethods, func(m objc.Method) bool {
 					return slices.Contains(props, m.Name) || slices.Contains(setters, m.Name)
 				})
-				fname := filepath.Join(o.conf.Output, o.conf.Name, proto.Name+"-Protocol.h")
+				fname := filepath.Join(frameworkDir, proto.Name+"-Protocol.h")
 				if err := writeHeader(&headerInfo{
 					FileName:      fname,
 					IpswVersion:   o.conf.IpswVersion,
@@ -561,9 +590,9 @@ func (o *ObjC) Headers() error {
 			return cmp.Compare(a.Name, b.Name)
 		})
 		for _, cat := range cats {
-			fname := filepath.Join(o.conf.Output, o.conf.Name, cat.Name+".h")
+			fname := filepath.Join(frameworkDir, cat.Name+".h")
 			if cat.Class != nil && cat.Class.Name != "" {
-				fname = filepath.Join(o.conf.Output, o.conf.Name, cat.Class.Name+"+"+cat.Name+".h")
+				fname = filepath.Join(frameworkDir, cat.Class.Name+"+"+cat.Name+".h")
 			}
 			var name string
 			if cat.Class != nil && cat.Class.Name != "" {
@@ -598,7 +627,7 @@ func (o *ObjC) Headers() error {
 				headers[i] = "#import \"" + header + "\""
 			}
 
-			fname := filepath.Join(o.conf.Output, o.conf.Name, umbrella+".h")
+			fname := filepath.Join(frameworkDir, umbrella+".h")
 			if err := writeHeader(&headerInfo{
 				FileName:      fname,
 				IpswVersion:   o.conf.IpswVersion,

--- a/internal/commands/macho/objc.go
+++ b/internal/commands/macho/objc.go
@@ -145,6 +145,12 @@ type ObjC struct {
 	deps  []*macho.File
 
 	baseFWs map[string][]string
+
+	// flatOutput suppresses the DSC-aware <framework-relative-path> routing
+	// in Headers() and writes headers directly under o.conf.Output. Used by
+	// XCFramework() so the generated <Name>.framework/Headers/ layout
+	// matches what the modulemap expects.
+	flatOutput bool
 }
 
 // NewObjC returns a new MachO ObjC parser instance
@@ -474,7 +480,7 @@ func (o *ObjC) Headers() error {
 		}
 		if id := m.DylibID(); id != nil {
 			binaryName = filepath.Base(id.Name)
-			if o.cache != nil {
+			if o.cache != nil && !o.flatOutput {
 				if filepath.IsAbs(id.Name) {
 					frameworkRelPath = safeRelPath(id.Name)
 				} else {
@@ -483,11 +489,22 @@ func (o *ObjC) Headers() error {
 			} else {
 				frameworkRelPath = binaryName
 			}
-		} else if o.cache != nil {
+		} else if o.cache != nil && !o.flatOutput {
 			frameworkRelPath = safeRelPath(o.conf.Name)
 		}
+		// o.conf.Name is mutated below for downstream consumers (writeHeader name,
+		// umbrella filename); save/restore so iterations over o.deps don't carry
+		// the previous dylib's binaryName into the next frameworkRelPath
+		// derivation (which falls back to safeRelPath(o.conf.Name)).
+		originalConfName := o.conf.Name
 		o.conf.Name = binaryName
+		defer func() { o.conf.Name = originalConfName }()
 		frameworkDir := filepath.Join(o.conf.Output, frameworkRelPath)
+		if o.flatOutput {
+			// XCFramework() expects headers directly under o.conf.Output so the
+			// generated modulemap's umbrella reference resolves.
+			frameworkDir = o.conf.Output
+		}
 		var buildVersions []string
 		if bvers := m.GetLoadsByName("LC_BUILD_VERSION"); len(bvers) > 0 {
 			for _, bv := range bvers {
@@ -855,9 +872,13 @@ func (o *ObjC) XCFramework() error {
 	}
 
 	/* generate modulemap */
+	// Headers() emits the umbrella file as "<Name>-Umbrella.h" so the umbrella
+	// never collides with a class header that happens to share the framework's
+	// name (e.g. class "SpringBoard" inside SpringBoard.framework). Keep the
+	// modulemap's umbrella reference in sync with that naming.
 	if err := os.WriteFile(filepath.Join(fwfolder, "Modules", "module.modulemap"), fmt.Appendf(nil,
 		"module %s [system] {\n"+
-			"    header \"Headers/%s.h\"\n"+ // NOTE: this SHOULD be the umbrella header
+			"    umbrella header \"%s-Umbrella.h\"\n"+
 			"    export *\n"+
 			"}\n", o.conf.Name, o.conf.Name,
 	), 0o660); err != nil {
@@ -900,6 +921,10 @@ func (o *ObjC) XCFramework() error {
 	/* generate Headers */
 	o.conf.Headers = true
 	o.conf.Output = filepath.Join(fwfolder, "Headers")
+	// XCFramework's modulemap references "<Name>-Umbrella.h" relative to
+	// Headers/, so headers must be flat there (no DSC framework-relative
+	// subdirectory routing).
+	o.flatOutput = true
 	return o.Headers()
 }
 

--- a/internal/commands/macho/objc.go
+++ b/internal/commands/macho/objc.go
@@ -146,10 +146,8 @@ type ObjC struct {
 
 	baseFWs map[string][]string
 
-	// flatOutput suppresses the DSC-aware <framework-relative-path> routing
-	// in Headers() and writes headers directly under o.conf.Output. Used by
-	// XCFramework() so the generated <Name>.framework/Headers/ layout
-	// matches what the modulemap expects.
+	// flatOutput makes Headers() write directly under o.conf.Output
+	// instead of a DSC-relative subdirectory. Set by XCFramework().
 	flatOutput bool
 }
 
@@ -464,10 +462,8 @@ func (o *ObjC) Headers() error {
 
 		binaryName := filepath.Base(o.conf.Name)
 		frameworkRelPath := binaryName
-		// safeRelPath sanitizes a candidate path for joining under o.conf.Output.
-		// Returns binaryName as a fallback if the input would escape the output
-		// directory (e.g. via ".." segments, absolute paths, or symlink-style
-		// constructs) or is otherwise non-local.
+		// safeRelPath rejects paths that would escape o.conf.Output
+		// (absolute, contains "..", non-local), falling back to binaryName.
 		safeRelPath := func(p string) string {
 			cleaned := filepath.Clean(p)
 			if filepath.IsAbs(cleaned) {
@@ -492,17 +488,13 @@ func (o *ObjC) Headers() error {
 		} else if o.cache != nil && !o.flatOutput {
 			frameworkRelPath = safeRelPath(o.conf.Name)
 		}
-		// o.conf.Name is mutated below for downstream consumers (writeHeader name,
-		// umbrella filename); save/restore so iterations over o.deps don't carry
-		// the previous dylib's binaryName into the next frameworkRelPath
-		// derivation (which falls back to safeRelPath(o.conf.Name)).
+		// Save/restore o.conf.Name so a --deps iteration cannot leak the
+		// previous dylib's name into the next path derivation.
 		originalConfName := o.conf.Name
 		o.conf.Name = binaryName
 		defer func() { o.conf.Name = originalConfName }()
 		frameworkDir := filepath.Join(o.conf.Output, frameworkRelPath)
 		if o.flatOutput {
-			// XCFramework() expects headers directly under o.conf.Output so the
-			// generated modulemap's umbrella reference resolves.
 			frameworkDir = o.conf.Output
 		}
 		var buildVersions []string
@@ -679,8 +671,6 @@ func (o *ObjC) Headers() error {
 
 		/* generate umbrella header */
 		if len(headers) > 0 {
-			// Strip a trailing extension (e.g. ".dylib") so the umbrella file is
-			// named "<Stem>-Umbrella.h" rather than "<Foo>.dylib-Umbrella.h".
 			umbrellaBase := strings.TrimSuffix(o.conf.Name, filepath.Ext(o.conf.Name))
 			var umbrella = umbrellaBase + "-Umbrella"
 			slices.SortStableFunc(headers, func(a, b string) int {
@@ -772,7 +762,13 @@ type XCFrameworkConfig struct {
 func (o *ObjC) XCFramework() error {
 	var xcfw XCFrameworkConfig
 
-	xcfolder := filepath.Join(o.conf.Output, o.conf.Name+".xcframework")
+	// stem is o.conf.Name with any trailing extension stripped (e.g.
+	// "libMobileGestalt.dylib" -> "libMobileGestalt"). It is used for every
+	// on-disk bundle name (.xcframework / .framework / .tbd) and Info.plist
+	// field so the resulting tree never carries a ".dylib" segment.
+	stem := strings.TrimSuffix(o.conf.Name, filepath.Ext(o.conf.Name))
+
+	xcfolder := filepath.Join(o.conf.Output, stem+".xcframework")
 	if err := os.MkdirAll(xcfolder, 0o750); err != nil {
 		return fmt.Errorf("failed to create XCFramework folder: %w", err)
 	}
@@ -830,9 +826,9 @@ func (o *ObjC) XCFramework() error {
 	if err := enc.Encode(XCFrameworkInfoPlist{
 		AvailableLibraries: []XCFrameworkAvailableLibrary{
 			{
-				BinaryPath:               o.conf.Name + ".framework/" + o.conf.Name + ".tbd",
+				BinaryPath:               stem + ".framework/" + stem + ".tbd",
 				LibraryIdentifier:        xcfw.LibraryIdentifier,
-				LibraryPath:              o.conf.Name + ".framework",
+				LibraryPath:              stem + ".framework",
 				SupportedArchitectures:   xcfw.SupportedArchitectures,
 				SupportedPlatform:        xcfw.SupportedPlatform,
 				SupportedPlatformVariant: xcfw.SupportedPlatformVariant,
@@ -845,7 +841,7 @@ func (o *ObjC) XCFramework() error {
 	}
 
 	/* create folder structure */
-	fwfolder := filepath.Join(xcfolder, xcfw.LibraryIdentifier, o.conf.Name+".framework")
+	fwfolder := filepath.Join(xcfolder, xcfw.LibraryIdentifier, stem+".framework")
 	if err := os.MkdirAll(filepath.Join(fwfolder, "Headers"), 0o750); err != nil {
 		return fmt.Errorf("failed to create Headers folder: %w", err)
 	}
@@ -869,22 +865,20 @@ func (o *ObjC) XCFramework() error {
 		return fmt.Errorf("failed to generate tbd: %w", err)
 	}
 	outTBD += "...\n"
-	tbdFile := filepath.Join(fwfolder, o.conf.Name+".tbd")
+	tbdFile := filepath.Join(fwfolder, stem+".tbd")
 	if err = os.WriteFile(tbdFile, []byte(outTBD), 0o660); err != nil {
 		return fmt.Errorf("failed to write tbd file %s: %v", tbdFile, err)
 	}
 
 	/* generate modulemap */
-	// Headers() emits the umbrella file as "<Stem>-Umbrella.h" (with any
-	// trailing ".dylib"-style extension stripped). Keep the module name and
-	// the umbrella reference in sync; modulemap identifiers also can't
-	// contain '.', so the stem is required there too.
-	umbrellaBase := strings.TrimSuffix(o.conf.Name, filepath.Ext(o.conf.Name))
+	// Module name must be a valid C identifier; the umbrella header reference
+	// is a literal filename and may keep characters like '.' (e.g. "libobjc.A").
+	moduleName := sanitizeCIdent(stem)
 	if err := os.WriteFile(filepath.Join(fwfolder, "Modules", "module.modulemap"), fmt.Appendf(nil,
 		"module %s [system] {\n"+
 			"    umbrella header \"%s-Umbrella.h\"\n"+
 			"    export *\n"+
-			"}\n", umbrellaBase, umbrellaBase,
+			"}\n", moduleName, stem,
 	), 0o660); err != nil {
 		return fmt.Errorf("failed to write module.modulemap file: %v", err)
 	}
@@ -900,10 +894,10 @@ func (o *ObjC) XCFramework() error {
 	if err := enc.Encode(XCFrameworkLibraryInfoPlist{
 		BuildMachineOSBuild:           "23E224",
 		CFBundleDevelopmentRegion:     "en",
-		CFBundleExecutable:            o.conf.Name + ".tbd",
-		CFBundleIdentifier:            "com.apple." + strings.ToLower(o.conf.Name),
+		CFBundleExecutable:            stem + ".tbd",
+		CFBundleIdentifier:            "com.apple." + strings.ToLower(stem),
 		CFBundleInfoDictionaryVersion: "6.0",
-		CFBundleName:                  o.conf.Name,
+		CFBundleName:                  stem,
 		CFBundlePackageType:           "FMWK",
 		CFBundleShortVersionString:    "1.0",
 		CFBundleSignature:             "????",
@@ -925,10 +919,15 @@ func (o *ObjC) XCFramework() error {
 	/* generate Headers */
 	o.conf.Headers = true
 	o.conf.Output = filepath.Join(fwfolder, "Headers")
-	// XCFramework's modulemap references "<Name>-Umbrella.h" relative to
-	// Headers/, so headers must be flat there (no DSC framework-relative
-	// subdirectory routing).
+	// In flat mode every dep would land in the same Headers/ directory and
+	// would not be referenced by the umbrella, so suppress deps too.
+	prevFlatOutput, prevDeps := o.flatOutput, o.deps
 	o.flatOutput = true
+	o.deps = nil
+	defer func() {
+		o.flatOutput = prevFlatOutput
+		o.deps = prevDeps
+	}()
 	return o.Headers()
 }
 
@@ -938,8 +937,40 @@ func (o *ObjC) SwiftPackage() error {
 
 /* utils */
 
+// sanitizeCIdent maps s onto a valid C / Clang preprocessor identifier:
+// any rune outside [A-Za-z0-9_] becomes '_', and a leading digit is
+// prefixed with '_'. Empty input becomes "_". Used for #ifndef guards
+// and modulemap module names whose source strings (dylib stems, ObjC
+// class/category names) may contain '.', '+', '-', etc.
+func sanitizeCIdent(s string) string {
+	if s == "" {
+		return "_"
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 1)
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r == '_':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			if i == 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
 func writeHeader(hdr *headerInfo) error {
 	var out strings.Builder
+	// hdr.Name comes from class/protocol/category names or umbrella stems;
+	// any of these may contain characters the preprocessor rejects.
+	guard := sanitizeCIdent(hdr.Name)
 	out.WriteString(fmt.Sprintf(
 		"//\n"+
 			"//   Generated by https://github.com/blacktop/ipsw (%s)\n"+
@@ -952,8 +983,8 @@ func writeHeader(hdr *headerInfo) error {
 		hdr.IpswVersion,
 		strings.Join(hdr.BuildVersions, "\n//    - LC_BUILD_VERSION:  "),
 		hdr.SourceVersion,
-		hdr.Name,
-		hdr.Name))
+		guard,
+		guard))
 	if !hdr.IsUmbrella {
 		out.WriteString("@import Foundation;\n")
 	}
@@ -981,7 +1012,7 @@ func writeHeader(hdr *headerInfo) error {
 		out.WriteString("\n")
 	}
 	out.WriteString(fmt.Sprintf("%s\n", hdr.Object))
-	out.WriteString(fmt.Sprintf("#endif /* %s_h */\n", hdr.Name))
+	out.WriteString(fmt.Sprintf("#endif /* %s_h */\n", guard))
 
 	if err := os.MkdirAll(filepath.Dir(hdr.FileName), 0o750); err != nil {
 		return err

--- a/internal/commands/macho/objc.go
+++ b/internal/commands/macho/objc.go
@@ -679,7 +679,10 @@ func (o *ObjC) Headers() error {
 
 		/* generate umbrella header */
 		if len(headers) > 0 {
-			var umbrella = o.conf.Name + "-Umbrella"
+			// Strip a trailing extension (e.g. ".dylib") so the umbrella file is
+			// named "<Stem>-Umbrella.h" rather than "<Foo>.dylib-Umbrella.h".
+			umbrellaBase := strings.TrimSuffix(o.conf.Name, filepath.Ext(o.conf.Name))
+			var umbrella = umbrellaBase + "-Umbrella"
 			slices.SortStableFunc(headers, func(a, b string) int {
 				return cmp.Compare(a, b)
 			})
@@ -872,15 +875,16 @@ func (o *ObjC) XCFramework() error {
 	}
 
 	/* generate modulemap */
-	// Headers() emits the umbrella file as "<Name>-Umbrella.h" so the umbrella
-	// never collides with a class header that happens to share the framework's
-	// name (e.g. class "SpringBoard" inside SpringBoard.framework). Keep the
-	// modulemap's umbrella reference in sync with that naming.
+	// Headers() emits the umbrella file as "<Stem>-Umbrella.h" (with any
+	// trailing ".dylib"-style extension stripped). Keep the module name and
+	// the umbrella reference in sync; modulemap identifiers also can't
+	// contain '.', so the stem is required there too.
+	umbrellaBase := strings.TrimSuffix(o.conf.Name, filepath.Ext(o.conf.Name))
 	if err := os.WriteFile(filepath.Join(fwfolder, "Modules", "module.modulemap"), fmt.Appendf(nil,
 		"module %s [system] {\n"+
 			"    umbrella header \"%s-Umbrella.h\"\n"+
 			"    export *\n"+
-			"}\n", o.conf.Name, o.conf.Name,
+			"}\n", umbrellaBase, umbrellaBase,
 	), 0o660); err != nil {
 		return fmt.Errorf("failed to write module.modulemap file: %v", err)
 	}


### PR DESCRIPTION
## Summary

Two related improvements to `ipsw class-dump --headers`, motivated by [headers.82flex.com](https://headers.82flex.com) (a per-version archive of generated Apple framework headers):

1. **Stable, diff-friendly output.** Member order is now deterministic across runs, so cross-version diffs surface real ABI changes instead of churn.
2. **No output collisions for DSC dylibs sharing a basename.** e.g. `/System/Library/PrivateFrameworks/SpringBoard.framework/SpringBoard` vs. `/System/Library/AccessibilityBundles/SpringBoard.axbundle/SpringBoard` — previously they overwrote each other under `<-o>/SpringBoard/`.

## Changes

- Generic `dedupeKeepLastByKey` + lexicographic sort on every class/protocol/category member array.
- Umbrella header is always `<Name>-Umbrella.h` (avoids colliding with a class named after the framework, e.g. `SpringBoard.h`); umbrella import list is sorted.
- For DSC inputs, headers are routed under `<-o>/<framework-relative-path>` (derived from the dylib id, hardened with `filepath.Clean` + `filepath.IsLocal` against `..` traversal). Standalone Mach-O inputs keep the basename layout.
- `XCFramework()` modulemap updated to `umbrella header "<Name>-Umbrella.h"` and forces a flat `Headers/` layout to match.
- `o.conf.Name` is saved/restored per `writeHeaders` call so `--deps` cannot leak a previous dylib's name into the next path derivation.

### Why no property-accessor filter is reintroduced

The previous code collected `@property` names into `props`/`setters` and dropped ivars/methods that matched them. This PR removes that filter (rather than restoring it after the new sort/dedupe) because:

- It's a name-based heuristic that doesn't honor explicit `getter=` / `setter=` and can drop unrelated methods that happen to match `set<Cap>:` (the original code even had a `TODO` acknowledging this).
- It hides the exact signals the headers archive exists to surface — methods promoted to properties, `_foo` ivar vs. `foo` property, accessors moving between class and protocol.
- It is not needed for output stability; `dedupeKeepLastByKey` + sort handle that uniformly.

## Testing

```
DSC=22A3351__iPhone17,1/.../dyld_shared_cache_arm64e
./ipsw class-dump --headers -o out "$DSC" /System/Library/PrivateFrameworks/SpringBoard.framework/SpringBoard
./ipsw class-dump --headers -o out "$DSC" /System/Library/AccessibilityBundles/SpringBoard.axbundle/SpringBoard
./ipsw class-dump --headers --deps -o out-deps "$DSC" /System/Library/PrivateFrameworks/SpringBoard.framework/SpringBoard
./ipsw class-dump --xcfw    -o xcfw "$DSC" /usr/lib/libMobileGestalt.dylib
./ipsw class-dump --all --headers -o all "$DSC"
```

Both `SpringBoard` dylibs land in distinct directories; `--deps` headers are correctly routed per-dependency; the generated XCFramework's modulemap resolves against the emitted `<Name>-Umbrella.h`.

## AI Assistance

- Claude Opus 4.7
