### PR TITLE
fix(dyld): correct class-dump rsBase on iOS 15 (deadlock + bogus selectors)

### DIFF
--- a/pkg/dyld/image.go
+++ b/pkg/dyld/image.go
@@ -448,8 +448,8 @@ func (i *CacheImage) GetMacho() (*macho.File, error) {
 			return nil, err
 		}
 
-		if opt.GetVersion() >= 16 {
-			rsBase = opt.RelativeMethodListsBaseAddress(i.cache.objcOptRoAddr)
+		rsBase = opt.RelativeMethodListsBaseAddress(i.cache.objcOptRoAddr)
+		if _, ok := opt.(*ObjCOptimizationHeader); ok {
 			rsBase += i.cache.Headers[i.cache.UUID].SharedRegionStart // TODO: can I trust SharedRegionStart? should this be Mapping[0].Address?
 		}
 	}
@@ -491,11 +491,20 @@ func (i *CacheImage) GetPartialMacho() (*macho.File, error) {
 	}
 	i.CacheReader = NewCacheReader(0, 1<<63-1, i.cuuid)
 	var rsBase uint64
-	if _, err := i.cache.Image("/usr/lib/libobjc.A.dylib"); err == nil {
-		opt, err := i.cache.GetOptimizations()
-		if err == nil && opt.GetVersion() >= 16 {
-			rsBase = opt.RelativeMethodListsBaseAddress(i.cache.objcOptRoAddr)
-			rsBase += i.cache.Headers[i.cache.UUID].SharedRegionStart
+	// Skip rsBase resolution when this partial macho is libobjc itself:
+	// f.GetOptimizations() may call f.getOptimizationsOld() -> f.getLibObjC()
+	// -> image.GetPartialMacho() on the very same libobjc image, which would
+	// re-enter f.objcOptOnce and deadlock. libobjc's own selectors do not
+	// require rsBase resolution at the partial-macho stage.
+	if i.Name != "/usr/lib/libobjc.A.dylib" {
+		if _, err := i.cache.Image("/usr/lib/libobjc.A.dylib"); err == nil {
+			opt, err := i.cache.GetOptimizations()
+			if err == nil {
+				rsBase = opt.RelativeMethodListsBaseAddress(i.cache.objcOptRoAddr)
+				if _, ok := opt.(*ObjCOptimizationHeader); ok {
+					rsBase += i.cache.Headers[i.cache.UUID].SharedRegionStart
+				}
+			}
 		}
 	}
 	vma := types.VMAddrConverter{

--- a/pkg/dyld/objc.go
+++ b/pkg/dyld/objc.go
@@ -204,6 +204,7 @@ func (f *File) getOptimizationsOld() (Optimization, error) {
 	}
 
 	if s := libObjC.Section("__TEXT", "__objc_opt_ro"); s != nil {
+		f.objcOptRoAddr = s.Addr
 		uuid, off, err := f.GetOffset(s.Addr)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

Fix `class-dump` on iOS 15 (and earlier) shared caches. Refs #577.

On iOS 15 DSCs the previous logic broke in two ways:

1. `rsBase` (the relative-method-list base) was only computed when the
   objc-opt header version was `>= 16`. iOS 15 caches still use the legacy
   `ObjcOptT` optimization header, so `rsBase` stayed at `0` and every
   relative method-list selector resolved to a garbage address — class-dump
   output *looked* fine but every selector name was wrong.
2. `GetPartialMacho` resolves `rsBase` via `GetOptimizations`. For
   `libobjc.A.dylib` itself this re-enters the optimization lookup
   (`getOptimizationsOld` → `getLibObjC` → `image.GetPartialMacho` on the
   same image) and deadlocks on `f.objcOptOnce`.

Changes:

- `pkg/dyld/image.go`: compute `rsBase` unconditionally from the
  optimization's relative-method-list base; only add `SharedRegionStart`
  when the optimization is the LargeSharedCache `ObjCOptimizationHeader`
  (which stores the base as a cache-relative offset). Apply the same
  correction in both `GetMacho` and `GetPartialMacho`. In `GetPartialMacho`
  also skip the optimization lookup when the image being parsed *is*
  `libobjc.A.dylib`, breaking the re-entrancy.
- `pkg/dyld/objc.go`: persist `objcOptRoAddr` in `getOptimizationsOld` so
  the legacy code path resolves the correct `__objc_opt_ro` section
  address.

## Testing

`ipsw dyld class-dump --all <DSC>` against the system DSC of each release:

| iOS  | Build    | Result                                  |
|------|----------|-----------------------------------------|
| 15.2 | 19C57    | OK (no deadlock, selectors verified)    |
| 16.0 | 20A362   | OK (regression check)                   |
| 17.0 | 21A329   | OK                                      |
| 18.0 | 22A3351  | OK                                      |
| 26.2 | 23C55    | OK                                      |

Spot-checked selector strings on iOS 15 against the on-device classes —
all correct after the fix (random garbage before).

## AI Assistance

GitHub Copilot (Claude) helped narrow down the deadlock by tracing the
`objcOptOnce` re-entry path and drafted the early-return for the
`libobjc.A.dylib` self-reference case. I personally reviewed every code
change, ran the five-version `class-dump --all` matrix above, and
verified the resulting selectors against on-device class metadata before
opening this PR.
