### PR TITLE
Fix plist command for array data

### DIFF
--- a/cmd/ipsw/cmd/pl.go
+++ b/cmd/ipsw/cmd/pl.go
@@ -55,7 +55,7 @@ func readAllPlists(inpath string) error {
 			return nil
 		}
 		if !info.IsDir() {
-			settings := make(map[string]any)
+			var settings any
 			data, err := os.ReadFile(path)
 			if err != nil {
 				if errors.Is(err, os.ErrPermission) {
@@ -148,7 +148,7 @@ var plistCmd = &cobra.Command{
 						}
 						log.Infof("event: %s", event.String())
 
-						settings := make(map[string]any)
+						var settings any
 						data, err := os.ReadFile(event.Name)
 						if err != nil {
 							log.Fatal(err.Error())

--- a/cmd/ipsw/cmd/pl.go
+++ b/cmd/ipsw/cmd/pl.go
@@ -234,7 +234,7 @@ var plistCmd = &cobra.Command{
 			}
 		}
 
-		var out map[string]any
+		var out any
 		if err := plist.NewDecoder(bytes.NewReader(data)).Decode(&out); err != nil {
 			return fmt.Errorf("failed to decode plist: %v", err)
 		}


### PR DESCRIPTION
## Summary

Changed the variable type from `map[string]any` to `any` because plist root elements are not always dictionaries `{}`, they can also be arrays `[]`.

## Testing

Test file: https://drive.google.com/file/d/1IE_-XpqsAjfqwEDyqtHBfynKtVHkxBsA/view

```powershell
.\ipsw.exe plist .\file.plist

failed to decode plist: plist: type mismatch: tried to decode plist type `array' into value of type `map[string]interface {}'
```

## AI Assistance

None
