### PR TITLE
Reduce IPSW end-to-end latency by up to 5x

### DIFF
--- a/internal/commands/extract/extract.go
+++ b/internal/commands/extract/extract.go
@@ -38,6 +38,10 @@ import (
 
 var ErrNoDecryptionKey = errors.New("no decryption key found")
 
+// Remote firmware extraction reads multi-GB ZIP members; larger blocks avoid
+// thousands of tiny HTTP range requests from ranger's 128 KiB default.
+const remoteFirmwareZipBlockSize = 8 * 1024 * 1024
+
 type remoteKernelcacheMember struct {
 	file    *zip.File
 	devices []string
@@ -249,8 +253,9 @@ func getFolder(c *Config) (*info.Info, string, error) {
 
 func getRemoteFolder(c *Config) (*info.Info, *zip.Reader, string, error) {
 	zr, err := download.NewRemoteZipReader(c.URL, &download.RemoteConfig{
-		Proxy:    c.Proxy,
-		Insecure: c.Insecure,
+		Proxy:     c.Proxy,
+		Insecure:  c.Insecure,
+		BlockSize: remoteFirmwareZipBlockSize,
 	})
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("unable to download remote zip: %v", err)

--- a/internal/download/remote.go
+++ b/internal/download/remote.go
@@ -15,6 +15,9 @@ import (
 type RemoteConfig struct {
 	Proxy    string
 	Insecure bool
+	// BlockSize controls the ranger HTTP range request block size. If unset,
+	// ranger's default block size is used.
+	BlockSize int
 }
 
 // NewRemoteZipReader returns a new remote zip file reader
@@ -37,6 +40,9 @@ func NewRemoteZipReader(zipURL string, config *RemoteConfig) (*zip.Reader, error
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create ranger reader")
+	}
+	if config.BlockSize > 0 {
+		reader.BlockSize = config.BlockSize
 	}
 
 	length, err := reader.Length()


### PR DESCRIPTION
## Overview        

This patch increases the `ranger.Reader` block size from the default 128 KiB to
8 MiB when performing remote (HTTP range-request) extraction of firmware ZIPs
(IPSW/OTA). The change is scoped to the firmware extraction path only; other
consumers of `download.NewRemoteZipReader` keep the existing default.                 
                                                            
All measurements are wall-clock times using the actual `ipsw` tool against
Apple's real CDN. The only change between runs is this patch.

## Test Environment                                 

- **Machine:**  8-core AMD EPYC-Genoa, 15 GB RAM, Linux 7.0.0-15-generic       
- **Go:**       1.26.0                                                                                                   
- **Internet:** Measured against Apple CDN (`updates.cdn-apple.com`):                                                                    
- **Download speed:**  980 MBit/s (single connection, 10 MB range)
- **Round-trip time:** ~18ms          
- **DMG mount:** Linux APFS kernel module (`apfs-dkms` 0.3.18) via `apfs-fuse` wrapper
- **Binaries:** `go build ./cmd/ipsw` twice from same commit         
  - `ipsw-unpatched`  (128 KiB blocks, ranger default)               
  - `ipsw-patched`    (8 MiB blocks, patch value)
                                                            
## Test A: Full end-to-end `--dyld --macos --latest`
                                                                                                                         
|                     | Before (128 KiB)      | After (8 MiB)       | Speedup |
| ------------------- | --------------------- | ------------------- | ------- |           
| **Wall-clock time** | 363.37s (6m 03s)      | 69.34s (1m 09s)     | **5.2x** |
| User CPU            | 48.13s                | 32.55s              |      
| System CPU          | 78.24s                | 56.63s              |
| Range requests*     | ~47,500               | ~742                | 64x     |

> *Estimated: 5.8 GB / block size                                                                                        
                                                                                                                         
- **Command:** `ipsw download ipsw --dyld --dyld-arch arm64e --macos --latest -y -o <dir>`
- **IPSW:** `UniversalMac_26.5_25F71_Restore.ipsw`        
- **File:** `094-56679-089.dmg.aea` (5.8 GB, extracted from remote ZIP then AEA-decrypted)
- **Output:** `dyld_shared_cache_arm64e` + 13 split files (5.5 GB total)
- **Status:** Both runs completed successfully. **Identical output files.**
                                                                                                                         
## Test B: `extract --remote --kernel` (iOS IPSW)   
                                                                                                                         
|                     | Before (128 KiB) | After (8 MiB) | Speedup |
| ------------------- | ---------------- | ------------- | ------- |
| **Wall-clock time** | 1.64s            | 0.78s         | **2.1x** |
| User CPU            | 0.45s            | 0.38s         |
| System CPU          | 0.36s            | 0.25s         |                                                               
| Range requests      | ~480             | ~8            | 60x     |

- **Command:** `ipsw extract --remote --kernel <iOS_IPSW_URL>`
- **File:** `kernelcache.release.iPhone14,2` (60 MB)
- **Status:** Both runs completed successfully. **Identical output.**
                                                                                                                                                                                       
                                                                                                                         
## Note on Memory                                                                                                        
                                                            
`ranger.Reader` caches every fetched block in memory with no eviction
(`reader.go:84`, `r.blocks[blockNumbers[i]] = v.Data`). For multi-GB DMGs,
this means the entire file occupies RAM during extraction. This is a
pre-existing ranger limitation, not introduced by the patch. The patch
only changes the block size — it does not affect caching behavior. 
                                                            
On machines with insufficient RAM for the full DMG, swap is needed.
The block size does not affect total cache size (always equals the
file size), but larger blocks mean fewer cached objects (lower map
overhead) and dramatically fewer HTTP range requests.                                                                    
                                                                                                                         
## Why 8 MiB (not 16 MiB)
                                                                                                                         
16 MiB was tested and measured slower than 8 MiB against the Apple CDN
(390 ms vs 253 ms for a 50 MiB member read). Apple's CDN appears to
have an internal chunk-size limit above ~8 MiB.
                                                                                                                         
## Commands That Benefit                       

All remote firmware extraction commands:

```                                                                                                                      
ipsw download ipsw --dyld ...                                                                                            
ipsw download ipsw --kernel ...                             
ipsw download ipsw --pattern ...                                                                                         
ipsw download ota --dyld ...                              
ipsw download ota --kernel ...                              
ipsw download ota --pattern ...
ipsw extract --remote --dyld <URL>                          
ipsw extract --remote --kernel <URL>    
ipsw extract --remote --pattern <REGEX> <URL>               
```
                                                            
## Commands NOT Affected       
                                                            
Normal full-file downloads (e.g. `ipsw download ipsw --device ...`) use the                                              
streaming downloader path and are not affected.
