### PR TITLE
feat(symbols): add `ipsw symbols --json` JSONL emitter

### DIFF
--- a/cmd/ipsw/cmd/symbols.go
+++ b/cmd/ipsw/cmd/symbols.go
@@ -35,7 +35,7 @@ import (
 func init() {
 	rootCmd.AddCommand(symbolsCmd)
 
-	symbolsCmd.Flags().Bool("json", false, "Emit symbols as JSONL (one JSON object per line)")
+	symbolsCmd.Flags().Bool("json", true, "Emit symbols as JSONL (one JSON object per line)")
 	symbolsCmd.Flags().Bool("dyld", false, "Include dyld_shared_cache dylib symbols")
 	symbolsCmd.Flags().Bool("kernel", false, "Include kernelcache/KEXT symbols")
 	symbolsCmd.Flags().Bool("filesystem", false, "Include file system Mach-O symbols")
@@ -73,10 +73,6 @@ results to the daemon.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if Verbose {
 			log.SetLevel(log.DebugLevel)
-		}
-
-		if !viper.GetBool("symbols.json") {
-			return fmt.Errorf("only JSONL output is supported; pass --json")
 		}
 
 		// Default to all sources when none are explicitly selected.

--- a/cmd/ipsw/cmd/symbols.go
+++ b/cmd/ipsw/cmd/symbols.go
@@ -1,0 +1,114 @@
+/*
+Copyright © 2018-2026 blacktop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/apex/log"
+	"github.com/blacktop/ipsw/internal/syms"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	rootCmd.AddCommand(symbolsCmd)
+
+	symbolsCmd.Flags().Bool("json", false, "Emit symbols as JSONL (one JSON object per line)")
+	symbolsCmd.Flags().Bool("dyld", false, "Include dyld_shared_cache dylib symbols")
+	symbolsCmd.Flags().Bool("kernel", false, "Include kernelcache/KEXT symbols")
+	symbolsCmd.Flags().Bool("filesystem", false, "Include file system Mach-O symbols")
+	symbolsCmd.Flags().String("signatures", "", "Path to kernel symbolication signatures directory")
+	symbolsCmd.Flags().String("pem-db", "", "AEA pem DB JSON file")
+	symbolsCmd.Flags().StringP("output", "o", "", "Output file path (\"-\" or unset for stdout)")
+
+	viper.BindPFlag("symbols.json", symbolsCmd.Flags().Lookup("json"))
+	viper.BindPFlag("symbols.dyld", symbolsCmd.Flags().Lookup("dyld"))
+	viper.BindPFlag("symbols.kernel", symbolsCmd.Flags().Lookup("kernel"))
+	viper.BindPFlag("symbols.filesystem", symbolsCmd.Flags().Lookup("filesystem"))
+	viper.BindPFlag("symbols.signatures", symbolsCmd.Flags().Lookup("signatures"))
+	viper.BindPFlag("symbols.pem-db", symbolsCmd.Flags().Lookup("pem-db"))
+	viper.BindPFlag("symbols.output", symbolsCmd.Flags().Lookup("output"))
+
+	symbolsCmd.MarkZshCompPositionalArgumentFile(1, "*.ipsw", "*.zip")
+}
+
+// symbolsCmd represents the symbols command
+var symbolsCmd = &cobra.Command{
+	Use:   "symbols <IPSW>",
+	Short: "Emit IPSW symbols as JSONL",
+	Long: `Emit every symbol in an IPSW as newline-delimited JSON (JSONL).
+
+The stream is emitted in this order: one "ipsw" line, then for each image an
+"image" line immediately followed by that image's "symbol" lines. Each
+dyld_shared_cache also emits a one-time "dsc" line carrying shared_region_start,
+which its dylib images reference via dsc_uuid.
+
+Kernel and KEXT symbol addresses are bit-63-cleared exactly as the ipswd symbol
+database stores them, so a server backed by this output returns byte-identical
+results to the daemon.`,
+	Args:          cobra.ExactArgs(1),
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if Verbose {
+			log.SetLevel(log.DebugLevel)
+		}
+
+		if !viper.GetBool("symbols.json") {
+			return fmt.Errorf("only JSONL output is supported; pass --json")
+		}
+
+		// Default to all sources when none are explicitly selected.
+		kernel := viper.GetBool("symbols.kernel")
+		dyld := viper.GetBool("symbols.dyld")
+		filesystem := viper.GetBool("symbols.filesystem")
+		if !kernel && !dyld && !filesystem {
+			kernel, dyld, filesystem = true, true, true
+		}
+
+		ipswPath := filepath.Clean(args[0])
+		if _, err := os.Stat(ipswPath); err != nil {
+			return fmt.Errorf("file %s does not exist: %w", ipswPath, err)
+		}
+
+		out := os.Stdout
+		if output := viper.GetString("symbols.output"); output != "" && output != "-" {
+			f, err := os.Create(output)
+			if err != nil {
+				return fmt.Errorf("failed to create output file %s: %w", output, err)
+			}
+			defer f.Close()
+			out = f
+		}
+
+		return syms.ScanJSONL(&syms.JSONLConfig{
+			IPSW:       ipswPath,
+			PemDB:      viper.GetString("symbols.pem-db"),
+			SigsDir:    viper.GetString("symbols.signatures"),
+			Kernel:     kernel,
+			DSC:        dyld,
+			FileSystem: filesystem,
+		}, out)
+	},
+}

--- a/cmd/ipsw/cmd/symbols_test.go
+++ b/cmd/ipsw/cmd/symbols_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSymbolsRunsWithoutJSONFlag(t *testing.T) {
+	t.Setenv("IPSW_NO_UPDATE_CHECK", "1")
+	missingIPSW := filepath.Join(t.TempDir(), "missing.ipsw")
+
+	err := symbolsCmd.RunE(symbolsCmd, []string{missingIPSW})
+	if err == nil {
+		t.Fatal("expected missing file error, got nil")
+	}
+	if strings.Contains(err.Error(), "only JSONL output is supported") {
+		t.Fatalf("symbols command still requires --json: %v", err)
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("err=%v, want missing file validation after default JSONL mode", err)
+	}
+}

--- a/internal/commands/mount/session.go
+++ b/internal/commands/mount/session.go
@@ -1,0 +1,87 @@
+package mount
+
+import (
+	"errors"
+	"sync"
+)
+
+// Session lazily mounts DMGs from a single IPSW and keeps them mounted for the
+// session's lifetime, so multiple consumers can share one mount per DMG instead
+// of each mounting (and re-extracting/re-decrypting) the same DMG.
+//
+// Each requested DMG type is mounted at most once; Close unmounts everything the
+// session mounted and removes the extracted backing files, exactly once. A
+// Session is safe for concurrent use.
+type Session struct {
+	ipswPath string
+	cfg      Config
+
+	mu     sync.Mutex
+	mounts map[string]*Context // dmg type ("sys"/"fs"/"app"/"exc"/"rdisk") -> mount
+
+	// seams for testing; default to the real mount/unmount primitives.
+	mount   func(typ string) (*Context, error)
+	unmount func(*Context) error
+}
+
+// NewSession creates a Session for the given IPSW. cfg may be nil.
+func NewSession(ipswPath string, cfg *Config) *Session {
+	var c Config
+	if cfg != nil {
+		c = *cfg
+	}
+	s := &Session{
+		ipswPath: ipswPath,
+		cfg:      c,
+		mounts:   make(map[string]*Context),
+	}
+	s.mount = func(typ string) (*Context, error) {
+		return DmgInIPSW(s.ipswPath, typ, &s.cfg)
+	}
+	s.unmount = func(ctx *Context) error {
+		return ctx.Unmount()
+	}
+	return s
+}
+
+// Root mounts the DMG of the given type (one of DmgTypes) if it is not already
+// mounted by this session, and returns its mount point. Repeated calls for the
+// same type return the cached mount without re-mounting.
+func (s *Session) Root(typ string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if ctx, ok := s.mounts[typ]; ok {
+		return ctx.MountPoint, nil
+	}
+	ctx, err := s.mount(typ)
+	if err != nil {
+		return "", err
+	}
+	s.mounts[typ] = ctx
+	return ctx.MountPoint, nil
+}
+
+// Close unmounts every DMG this session mounted and removes the extracted
+// backing files. DMGs that were already mounted before the session acquired
+// them (AlreadyMounted) are left in place, and DMGs that resolved to the same
+// mount point (e.g. "sys" falling back to "fs" on pre-cryptex IPSWs) are
+// unmounted only once. It is safe to call Close more than once.
+func (s *Session) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	seen := make(map[string]bool, len(s.mounts))
+	var errs []error
+	for _, ctx := range s.mounts {
+		if ctx.AlreadyMounted || seen[ctx.MountPoint] {
+			continue
+		}
+		seen[ctx.MountPoint] = true
+		if err := s.unmount(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	s.mounts = make(map[string]*Context)
+	return errors.Join(errs...)
+}

--- a/internal/commands/mount/session_test.go
+++ b/internal/commands/mount/session_test.go
@@ -1,0 +1,103 @@
+package mount
+
+import (
+	"errors"
+	"slices"
+	"testing"
+)
+
+// newTestSession returns a Session whose mount/unmount are backed by fakes so
+// the caching and cleanup logic can be exercised without real DMGs.
+func newTestSession(mountFn func(string) (*Context, error), unmounted *[]string) *Session {
+	s := &Session{mounts: make(map[string]*Context)}
+	s.mount = mountFn
+	s.unmount = func(ctx *Context) error {
+		*unmounted = append(*unmounted, ctx.MountPoint)
+		return nil
+	}
+	return s
+}
+
+func TestSessionRootMountsOncePerType(t *testing.T) {
+	calls := map[string]int{}
+	var unmounted []string
+	s := newTestSession(func(typ string) (*Context, error) {
+		calls[typ]++
+		return &Context{MountPoint: "/mnt/" + typ}, nil
+	}, &unmounted)
+
+	for range 3 {
+		mp, err := s.Root("sys")
+		if err != nil {
+			t.Fatalf("Root(sys): %v", err)
+		}
+		if mp != "/mnt/sys" {
+			t.Fatalf("mount point = %q, want /mnt/sys", mp)
+		}
+	}
+	if _, err := s.Root("fs"); err != nil {
+		t.Fatalf("Root(fs): %v", err)
+	}
+
+	if calls["sys"] != 1 {
+		t.Errorf("sys mounted %d times, want 1", calls["sys"])
+	}
+	if calls["fs"] != 1 {
+		t.Errorf("fs mounted %d times, want 1", calls["fs"])
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	slices.Sort(unmounted)
+	if !slices.Equal(unmounted, []string{"/mnt/fs", "/mnt/sys"}) {
+		t.Errorf("unmounted = %v, want each distinct mount once", unmounted)
+	}
+}
+
+func TestSessionCloseDedupsAliasedMountsAndSkipsExternal(t *testing.T) {
+	var unmounted []string
+	s := newTestSession(func(typ string) (*Context, error) {
+		switch typ {
+		case "sys", "fs":
+			// Pre-cryptex IPSW: "sys" falls back to the same DMG as "fs".
+			return &Context{MountPoint: "/mnt/shared"}, nil
+		case "app":
+			// Pre-existing mount owned by someone else; must not be unmounted.
+			return &Context{MountPoint: "/mnt/app", AlreadyMounted: true}, nil
+		default:
+			return &Context{MountPoint: "/mnt/" + typ}, nil
+		}
+	}, &unmounted)
+
+	for _, typ := range []string{"sys", "fs", "app"} {
+		if _, err := s.Root(typ); err != nil {
+			t.Fatalf("Root(%s): %v", typ, err)
+		}
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !slices.Equal(unmounted, []string{"/mnt/shared"}) {
+		t.Errorf("unmounted = %v, want only /mnt/shared once (alias deduped, external skipped)", unmounted)
+	}
+}
+
+func TestSessionRootPropagatesMountError(t *testing.T) {
+	want := errors.New("boom")
+	var unmounted []string
+	s := newTestSession(func(string) (*Context, error) {
+		return nil, want
+	}, &unmounted)
+
+	if _, err := s.Root("exc"); !errors.Is(err, want) {
+		t.Fatalf("Root error = %v, want %v", err, want)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close after failed mount: %v", err)
+	}
+	if len(unmounted) != 0 {
+		t.Errorf("unmounted = %v, want nothing (mount failed)", unmounted)
+	}
+}

--- a/internal/syms/jsonl.go
+++ b/internal/syms/jsonl.go
@@ -160,20 +160,15 @@ func ScanJSONL(cfg *JSONLConfig, w io.Writer) error {
 		return err
 	}
 
-	if cfg.Kernel {
-		if err := scanKernels(cfg.IPSW, cfg.SigsDir, em.image); err != nil {
-			return fmt.Errorf("failed to scan kernels: %w", err)
-		}
-	}
-	if cfg.DSC {
-		if err := scanDSCs(cfg.IPSW, cfg.PemDB, em.image); err != nil {
-			return fmt.Errorf("failed to scan DSCs: %w", err)
-		}
-	}
-	if cfg.FileSystem {
-		if err := scanFileSystem(cfg.IPSW, cfg.PemDB, em.image); err != nil {
-			return fmt.Errorf("failed to scan file system machos: %w", err)
-		}
+	if err := scanIPSW(&scanConfig{
+		IPSW:       cfg.IPSW,
+		PemDB:      cfg.PemDB,
+		SigsDir:    cfg.SigsDir,
+		Kernel:     cfg.Kernel,
+		DSC:        cfg.DSC,
+		FileSystem: cfg.FileSystem,
+	}, em.image); err != nil {
+		return err
 	}
 
 	return bw.Flush()

--- a/internal/syms/jsonl.go
+++ b/internal/syms/jsonl.go
@@ -1,0 +1,197 @@
+package syms
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/blacktop/ipsw/internal/model"
+	"github.com/blacktop/ipsw/internal/utils"
+	"github.com/blacktop/ipsw/pkg/info"
+)
+
+// JSONLConfig configures a streaming JSONL symbol scan.
+type JSONLConfig struct {
+	IPSW       string
+	PemDB      string
+	SigsDir    string
+	Kernel     bool
+	DSC        bool
+	FileSystem bool
+}
+
+// ipswLine is the single leading record describing the scanned IPSW.
+type ipswLine struct {
+	Type     string   `json:"type"`
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	Version  string   `json:"version"`
+	Build    string   `json:"build"`
+	Platform string   `json:"platform"`
+	Devices  []string `json:"devices"`
+}
+
+// dscLine is emitted once per dyld_shared_cache, carrying its shared_region_start.
+// Each dylib image references it by dsc_uuid.
+type dscLine struct {
+	Type              string `json:"type"`
+	UUID              string `json:"uuid"`
+	SharedRegionStart uint64 `json:"shared_region_start"`
+}
+
+// imageLine describes a single Mach-O image. dsc_uuid is set for dylibs and
+// kernel_version for the kernel cache; both are omitted otherwise.
+type imageLine struct {
+	Type          string `json:"type"`
+	UUID          string `json:"uuid"`
+	Kind          string `json:"kind"`
+	Path          string `json:"path"`
+	TextStart     uint64 `json:"text_start"`
+	TextEnd       uint64 `json:"text_end"`
+	CPU           string `json:"cpu"`
+	Arch          string `json:"arch"`
+	DSCUUID       string `json:"dsc_uuid,omitempty"`
+	KernelVersion string `json:"kernel_version,omitempty"`
+}
+
+// symbolLine describes a single symbol within the most recently emitted image.
+type symbolLine struct {
+	Type      string `json:"type"`
+	ImageUUID string `json:"image_uuid"`
+	Name      string `json:"name"`
+	Start     uint64 `json:"start"`
+	End       uint64 `json:"end"`
+}
+
+// jsonlEmitter writes scan results as newline-delimited JSON.
+type jsonlEmitter struct {
+	enc *json.Encoder
+}
+
+func newJSONLEmitter(w io.Writer) *jsonlEmitter {
+	enc := json.NewEncoder(w)
+	// Symbol names and paths are emitted verbatim; HTML escaping would alter
+	// names containing <, > or & and break byte-identical name matching.
+	enc.SetEscapeHTML(false)
+	return &jsonlEmitter{enc: enc}
+}
+
+func (e *jsonlEmitter) emit(v any) error {
+	return e.enc.Encode(v)
+}
+
+// image is a scanVisitor: it emits the image line (or a dsc container line)
+// immediately followed by that image's symbol lines.
+func (e *jsonlEmitter) image(img *scanImage) error {
+	if img.Kind == "dsc" {
+		return e.emit(&dscLine{
+			Type:              "dsc",
+			UUID:              img.DSCUUID,
+			SharedRegionStart: img.SharedRegionStart,
+		})
+	}
+	if err := e.emit(&imageLine{
+		Type:          "image",
+		UUID:          img.Macho.UUID,
+		Kind:          img.Kind,
+		Path:          img.Macho.GetPath(),
+		TextStart:     img.Macho.TextStart,
+		TextEnd:       img.Macho.TextEnd,
+		CPU:           img.CPU,
+		Arch:          img.Arch,
+		DSCUUID:       img.DSCUUID,
+		KernelVersion: img.KernelVersion,
+	}); err != nil {
+		return err
+	}
+	for _, sym := range img.Macho.Symbols {
+		if err := e.emit(&symbolLine{
+			Type:      "symbol",
+			ImageUUID: img.Macho.UUID,
+			Name:      sym.GetName(),
+			Start:     sym.Start,
+			End:       sym.End,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ScanJSONL scans an IPSW and streams its symbols to w as newline-delimited JSON
+// (JSONL). It emits one "ipsw" line, then for every image an "image" line
+// immediately followed by that image's "symbol" lines (and a one-time "dsc" line
+// per shared cache, carrying shared_region_start, which each dylib references via
+// dsc_uuid). Symbols are written as they are discovered, so the full symbol set
+// is never held in memory.
+//
+// The emitted addresses use the same normalization as the daemon database, so a
+// server backed by this output returns byte-identical results to ipswd.
+func ScanJSONL(cfg *JSONLConfig, w io.Writer) error {
+	bw := bufio.NewWriter(w)
+	em := newJSONLEmitter(bw)
+
+	sha1, err := utils.Sha1(cfg.IPSW)
+	if err != nil {
+		return fmt.Errorf("failed to calculate sha1: %w", err)
+	}
+	inf, err := info.Parse(cfg.IPSW)
+	if err != nil {
+		return fmt.Errorf("failed to parse IPSW info: %w", err)
+	}
+	if err := em.emit(&ipswLine{
+		Type:     "ipsw",
+		ID:       sha1,
+		Name:     filepath.Base(cfg.IPSW),
+		Version:  inf.Plists.BuildManifest.ProductVersion,
+		Build:    inf.Plists.BuildManifest.ProductBuildVersion,
+		Platform: string(platformFromInfo(inf)),
+		Devices:  inf.Plists.BuildManifest.SupportedProductTypes,
+	}); err != nil {
+		return err
+	}
+
+	if cfg.Kernel {
+		if err := scanKernels(cfg.IPSW, cfg.SigsDir, em.image); err != nil {
+			return fmt.Errorf("failed to scan kernels: %w", err)
+		}
+	}
+	if cfg.DSC {
+		if err := scanDSCs(cfg.IPSW, cfg.PemDB, em.image); err != nil {
+			return fmt.Errorf("failed to scan DSCs: %w", err)
+		}
+	}
+	if cfg.FileSystem {
+		if err := scanFileSystem(cfg.IPSW, cfg.PemDB, em.image); err != nil {
+			return fmt.Errorf("failed to scan file system machos: %w", err)
+		}
+	}
+
+	return bw.Flush()
+}
+
+// platformFromInfo derives the Apple platform for an IPSW from its supported
+// product types. The daemon database does not persist this, so the JSONL emitter
+// derives it independently.
+func platformFromInfo(inf *info.Info) model.Platform {
+	for _, dev := range inf.Plists.BuildManifest.SupportedProductTypes {
+		switch {
+		case strings.HasPrefix(dev, "Mac"):
+			return model.PlatformMacOS
+		case strings.HasPrefix(dev, "AppleTV"):
+			return model.PlatformTvOS
+		case strings.HasPrefix(dev, "Watch"):
+			return model.PlatformWatchOS
+		case strings.HasPrefix(dev, "RealityDevice"):
+			return model.PlatformVisionOS
+		case strings.HasPrefix(dev, "iPhone"),
+			strings.HasPrefix(dev, "iPad"),
+			strings.HasPrefix(dev, "iPod"):
+			return model.PlatformIOS
+		}
+	}
+	return model.PlatformIOS
+}

--- a/internal/syms/jsonl.go
+++ b/internal/syms/jsonl.go
@@ -132,6 +132,9 @@ func (e *jsonlEmitter) image(img *scanImage) error {
 // server backed by this output returns byte-identical results to ipswd.
 func ScanJSONL(cfg *JSONLConfig, w io.Writer) error {
 	bw := bufio.NewWriter(w)
+	// Flush buffered lines on every return path, including early errors, so an
+	// aborted scan still writes the records it already produced.
+	defer bw.Flush()
 	em := newJSONLEmitter(bw)
 
 	sha1, err := utils.Sha1(cfg.IPSW)
@@ -141,6 +144,9 @@ func ScanJSONL(cfg *JSONLConfig, w io.Writer) error {
 	inf, err := info.Parse(cfg.IPSW)
 	if err != nil {
 		return fmt.Errorf("failed to parse IPSW info: %w", err)
+	}
+	if inf.Plists == nil || inf.Plists.BuildManifest == nil {
+		return fmt.Errorf("missing BuildManifest in %s (not a valid IPSW?)", cfg.IPSW)
 	}
 	if err := em.emit(&ipswLine{
 		Type:     "ipsw",

--- a/internal/syms/jsonl_test.go
+++ b/internal/syms/jsonl_test.go
@@ -190,10 +190,10 @@ func TestDBAccumulatorMatchesGraph(t *testing.T) {
 		{Kind: "dsc", DSCUUID: "DSC1", SharedRegionStart: 0x1800},
 		{Kind: "dylib", DSCUUID: "DSC1", Macho: &model.Macho{UUID: "D1", Symbols: []*model.Symbol{{Start: 1, End: 2}}}},
 		// Fileset kernel: container (no symbols) then a kext.
-		{Kind: "kernel", KernelVersion: "v1", Macho: &model.Macho{UUID: "KC1"}},
+		{Kind: "kernel", IsFileset: true, KernelVersion: "v1", Macho: &model.Macho{UUID: "KC1"}},
 		{Kind: "kext", KernelUUID: "KC1", Macho: &model.Macho{UUID: "KX1", Symbols: []*model.Symbol{{Start: 3, End: 4}}}},
-		// Non-fileset kernel: container is also the only kext.
-		{Kind: "kernel", KernelVersion: "v2", Macho: &model.Macho{UUID: "KC2", Symbols: []*model.Symbol{{Start: 5, End: 6}}}},
+		// Non-fileset kernel: container is also the only kext, even when symbol-less.
+		{Kind: "kernel", KernelVersion: "v2", Macho: &model.Macho{UUID: "KC2"}},
 		{Kind: "macho", Macho: &model.Macho{UUID: "FS1", Symbols: []*model.Symbol{{Start: 7, End: 8}}}},
 	}
 	for _, img := range visit {
@@ -223,6 +223,84 @@ func TestDBAccumulatorMatchesGraph(t *testing.T) {
 	}
 	if len(ipsw.FileSystem) != 1 || ipsw.FileSystem[0].UUID != "FS1" {
 		t.Fatalf("unexpected file system: %+v", ipsw.FileSystem)
+	}
+}
+
+func TestRescanTargetDoesNotShareScannedGraph(t *testing.T) {
+	existing := &model.Ipsw{
+		ID:      "id",
+		Name:    "restore.ipsw",
+		Version: "26.0",
+		BuildID: "23A1",
+		Devices: []*model.Device{
+			{Name: "iPhone18,1"},
+		},
+		Kernels:    []*model.Kernelcache{{UUID: "old-kernel"}},
+		DSCs:       []*model.DyldSharedCache{{UUID: "old-dsc"}},
+		FileSystem: []*model.Macho{{UUID: "old-fs"}},
+	}
+
+	replacement := rescanTarget(existing)
+	if replacement.ID != existing.ID ||
+		replacement.Name != existing.Name ||
+		replacement.Version != existing.Version ||
+		replacement.BuildID != existing.BuildID {
+		t.Fatalf("replacement metadata = %+v, want %+v", replacement, existing)
+	}
+	if len(replacement.Devices) != 1 || replacement.Devices[0].Name != "iPhone18,1" {
+		t.Fatalf("replacement devices = %+v, want existing devices copied", replacement.Devices)
+	}
+	if len(replacement.Kernels) != 0 || len(replacement.DSCs) != 0 || len(replacement.FileSystem) != 0 {
+		t.Fatalf("replacement scan graph should start empty: %+v", replacement)
+	}
+
+	replacement.Kernels = append(replacement.Kernels, &model.Kernelcache{UUID: "new-kernel"})
+	if len(existing.Kernels) != 1 || existing.Kernels[0].UUID != "old-kernel" {
+		t.Fatalf("existing kernels mutated: %+v", existing.Kernels)
+	}
+}
+
+func TestOptionalVolumePresentDistinguishesAbsentFromInvalid(t *testing.T) {
+	present, err := optionalVolumePresent(testVolumeInfo(
+		map[string]string{"Cryptex1,AppOS": "app.dmg"},
+	), "app")
+	if err != nil || !present {
+		t.Fatalf("present app volume = %t, err=%v; want present with no error", present, err)
+	}
+
+	present, err = optionalVolumePresent(testVolumeInfo(map[string]string{}), "app")
+	if err != nil || present {
+		t.Fatalf("absent app volume = %t, err=%v; want absent with no error", present, err)
+	}
+
+	present, err = optionalVolumePresent(testVolumeInfo(
+		map[string]string{"Cryptex1,AppOS": "app1.dmg"},
+		map[string]string{"Cryptex1,AppOS": "app2.dmg"},
+	), "app")
+	if err == nil || present || !strings.Contains(err.Error(), "multiple AppOS DMGs") {
+		t.Fatalf("invalid app volume = %t, err=%v; want propagated invalid-manifest error", present, err)
+	}
+}
+
+func testVolumeInfo(manifests ...map[string]string) *info.Info {
+	buildIdentities := make([]plist.BuildIdentity, 0, len(manifests))
+	for _, manifest := range manifests {
+		buildIdentity := plist.BuildIdentity{
+			Manifest: make(map[string]plist.IdentityManifest, len(manifest)),
+		}
+		for key, path := range manifest {
+			buildIdentity.Manifest[key] = plist.IdentityManifest{
+				Info: map[string]any{"Path": path},
+			}
+		}
+		buildIdentities = append(buildIdentities, buildIdentity)
+	}
+	return &info.Info{
+		Plists: &plist.Plists{
+			BuildManifest: &plist.BuildManifest{
+				BuildIdentities: buildIdentities,
+			},
+		},
 	}
 }
 

--- a/internal/syms/jsonl_test.go
+++ b/internal/syms/jsonl_test.go
@@ -1,0 +1,252 @@
+package syms
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/blacktop/ipsw/internal/model"
+	"github.com/blacktop/ipsw/pkg/info"
+	"github.com/blacktop/ipsw/pkg/plist"
+)
+
+// decodeLines splits a JSONL buffer into a slice of generic maps, one per line.
+func decodeLines(t *testing.T, b []byte) []map[string]any {
+	t.Helper()
+	var lines []map[string]any
+	sc := bufio.NewScanner(bytes.NewReader(b))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		raw := sc.Bytes()
+		if len(strings.TrimSpace(string(raw))) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("invalid JSON line %q: %v", string(raw), err)
+		}
+		lines = append(lines, m)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	return lines
+}
+
+// TestEmitterLineTypesAndFields drives the JSONL emitter with synthetic images
+// and asserts the line types, field names, and lossless symbol round-trip
+// without needing a real IPSW.
+func TestEmitterLineTypesAndFields(t *testing.T) {
+	var buf bytes.Buffer
+	em := newJSONLEmitter(&buf)
+
+	if err := em.emit(&ipswLine{
+		Type:     "ipsw",
+		ID:       "abc123",
+		Name:     "iPhone18,1_26.5_23F75_Restore.ipsw",
+		Version:  "26.5",
+		Build:    "23F75",
+		Platform: string(model.PlatformIOS),
+		Devices:  []string{"iPhone18,1"},
+	}); err != nil {
+		t.Fatalf("emit ipsw: %v", err)
+	}
+
+	// DSC container + one dylib carrying a single symbol.
+	if err := em.image(&scanImage{
+		Kind:              "dsc",
+		DSCUUID:           "DSC-UUID",
+		SharedRegionStart: 0x180000000,
+	}); err != nil {
+		t.Fatalf("emit dsc: %v", err)
+	}
+	const (
+		symStart uint64 = 0x1DC2A1000
+		symEnd   uint64 = 0x1DC2A1100
+		probe    uint64 = 0x1DC2A1050 // start <= probe < end
+	)
+	if err := em.image(&scanImage{
+		Kind:    "dylib",
+		CPU:     "arm64e",
+		Arch:    "arm64e",
+		DSCUUID: "DSC-UUID",
+		Macho: &model.Macho{
+			UUID:      "DYLIB-UUID",
+			Path:      model.Path{Path: "/usr/lib/libobjc.A.dylib"},
+			TextStart: 0x1DC2A0000,
+			TextEnd:   0x1DC2B0000,
+			Symbols: []*model.Symbol{
+				{Name: model.Name{Name: "_objc_msgSend"}, Start: symStart, End: symEnd},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("emit dylib: %v", err)
+	}
+
+	// Kernel image carrying kernel_version.
+	if err := em.image(&scanImage{
+		Kind:          "kernel",
+		CPU:           "arm64e",
+		Arch:          "arm64e",
+		KernelVersion: "Darwin Kernel Version 26.5",
+		Macho: &model.Macho{
+			UUID:      "KERNEL-UUID",
+			Path:      model.Path{Path: "kernelcache"},
+			TextStart: 0xFFFFFE0007004000,
+			TextEnd:   0xFFFFFE0007804000,
+		},
+	}); err != nil {
+		t.Fatalf("emit kernel: %v", err)
+	}
+
+	lines := decodeLines(t, buf.Bytes())
+	// Line order: ipsw, dsc, image(dylib), symbol, image(kernel).
+	wantTypes := []string{"ipsw", "dsc", "image", "symbol", "image"}
+	if len(lines) != len(wantTypes) {
+		t.Fatalf("expected %d lines, got %d: %v", len(wantTypes), len(lines), lines)
+	}
+	for i, want := range wantTypes {
+		if lines[i]["type"] != want {
+			t.Fatalf("line[%d] type = %v, want %s", i, lines[i]["type"], want)
+		}
+	}
+
+	// The dsc line must carry shared_region_start.
+	dsc := lines[1]
+	if dsc["type"] != "dsc" {
+		t.Fatalf("line[1] type = %v, want dsc", dsc["type"])
+	}
+	if _, ok := dsc["shared_region_start"]; !ok {
+		t.Fatalf("dsc line missing shared_region_start: %v", dsc)
+	}
+
+	// The dylib image line: kind=dylib, dsc_uuid set, text range present.
+	img := lines[2]
+	if img["type"] != "image" || img["kind"] != "dylib" {
+		t.Fatalf("line[2] = %v, want image/dylib", img)
+	}
+	for _, f := range []string{"uuid", "kind", "path", "text_start", "text_end", "cpu", "arch", "dsc_uuid"} {
+		if _, ok := img[f]; !ok {
+			t.Fatalf("image line missing field %q: %v", f, img)
+		}
+	}
+	if img["dsc_uuid"] != "DSC-UUID" {
+		t.Fatalf("image dsc_uuid = %v, want DSC-UUID", img["dsc_uuid"])
+	}
+
+	// The symbol line: image_uuid + numeric start/end matching the input.
+	sym := lines[3]
+	if sym["type"] != "symbol" {
+		t.Fatalf("line[3] type = %v, want symbol", sym["type"])
+	}
+	for _, f := range []string{"image_uuid", "name", "start", "end"} {
+		if _, ok := sym[f]; !ok {
+			t.Fatalf("symbol line missing field %q: %v", f, sym)
+		}
+	}
+	if sym["image_uuid"] != "DYLIB-UUID" {
+		t.Fatalf("symbol image_uuid = %v, want DYLIB-UUID", sym["image_uuid"])
+	}
+	gotStart, ok := sym["start"].(float64)
+	if !ok {
+		t.Fatalf("symbol start is not a JSON number: %T", sym["start"])
+	}
+	gotEnd, ok := sym["end"].(float64)
+	if !ok {
+		t.Fatalf("symbol end is not a JSON number: %T", sym["end"])
+	}
+	if uint64(gotStart) != symStart || uint64(gotEnd) != symEnd {
+		t.Fatalf("symbol [start,end) = [%d,%d), want [%d,%d)", uint64(gotStart), uint64(gotEnd), symStart, symEnd)
+	}
+	// Lossless round-trip: an address resolvable via start <= addr < end is
+	// derivable from the emitted JSONL.
+	if !(probe >= uint64(gotStart) && probe < uint64(gotEnd)) {
+		t.Fatalf("probe %#x not within emitted symbol range [%#x,%#x)", probe, uint64(gotStart), uint64(gotEnd))
+	}
+
+	// The kernel image line: kind=kernel and kernel_version present.
+	kern := lines[4]
+	if kern["type"] != "image" || kern["kind"] != "kernel" {
+		t.Fatalf("line[4] = %v, want image/kernel", kern)
+	}
+	if kern["kernel_version"] != "Darwin Kernel Version 26.5" {
+		t.Fatalf("kernel kernel_version = %v", kern["kernel_version"])
+	}
+	// A non-dylib image must not carry dsc_uuid (omitempty).
+	if _, ok := kern["dsc_uuid"]; ok {
+		t.Fatalf("kernel image unexpectedly carries dsc_uuid: %v", kern)
+	}
+}
+
+// TestDBAccumulatorMatchesGraph verifies the visitor rebuilds the same nested
+// model graph the daemon database persists.
+func TestDBAccumulatorMatchesGraph(t *testing.T) {
+	ipsw := &model.Ipsw{ID: "id"}
+	acc := newDBAccumulator(ipsw)
+
+	visit := []*scanImage{
+		{Kind: "dsc", DSCUUID: "DSC1", SharedRegionStart: 0x1800},
+		{Kind: "dylib", DSCUUID: "DSC1", Macho: &model.Macho{UUID: "D1", Symbols: []*model.Symbol{{Start: 1, End: 2}}}},
+		// Fileset kernel: container (no symbols) then a kext.
+		{Kind: "kernel", KernelVersion: "v1", Macho: &model.Macho{UUID: "KC1"}},
+		{Kind: "kext", KernelUUID: "KC1", Macho: &model.Macho{UUID: "KX1", Symbols: []*model.Symbol{{Start: 3, End: 4}}}},
+		// Non-fileset kernel: container is also the only kext.
+		{Kind: "kernel", KernelVersion: "v2", Macho: &model.Macho{UUID: "KC2", Symbols: []*model.Symbol{{Start: 5, End: 6}}}},
+		{Kind: "macho", Macho: &model.Macho{UUID: "FS1", Symbols: []*model.Symbol{{Start: 7, End: 8}}}},
+	}
+	for _, img := range visit {
+		if err := acc.visit(img); err != nil {
+			t.Fatalf("visit %s: %v", img.Kind, err)
+		}
+	}
+
+	if len(ipsw.DSCs) != 1 || ipsw.DSCs[0].UUID != "DSC1" || ipsw.DSCs[0].SharedRegionStart != 0x1800 {
+		t.Fatalf("unexpected DSCs: %+v", ipsw.DSCs)
+	}
+	if len(ipsw.DSCs[0].Images) != 1 || ipsw.DSCs[0].Images[0].UUID != "D1" {
+		t.Fatalf("unexpected DSC images: %+v", ipsw.DSCs[0].Images)
+	}
+	if len(ipsw.Kernels) != 2 {
+		t.Fatalf("expected 2 kernelcaches, got %d", len(ipsw.Kernels))
+	}
+	// Fileset kernel: container has no symbols, so its only kext is KX1.
+	kc1 := ipsw.Kernels[0]
+	if kc1.UUID != "KC1" || kc1.Version != "v1" || len(kc1.Kexts) != 1 || kc1.Kexts[0].UUID != "KX1" {
+		t.Fatalf("unexpected fileset kernel: %+v / kexts=%+v", kc1, kc1.Kexts)
+	}
+	// Non-fileset kernel: container is itself the single kext.
+	kc2 := ipsw.Kernels[1]
+	if kc2.UUID != "KC2" || kc2.Version != "v2" || len(kc2.Kexts) != 1 || kc2.Kexts[0].UUID != "KC2" {
+		t.Fatalf("unexpected non-fileset kernel: %+v / kexts=%+v", kc2, kc2.Kexts)
+	}
+	if len(ipsw.FileSystem) != 1 || ipsw.FileSystem[0].UUID != "FS1" {
+		t.Fatalf("unexpected file system: %+v", ipsw.FileSystem)
+	}
+}
+
+// TestPlatformFromInfo checks platform derivation from supported product types.
+func TestPlatformFromInfo(t *testing.T) {
+	cases := []struct {
+		device string
+		want   model.Platform
+	}{
+		{"iPhone18,1", model.PlatformIOS},
+		{"iPad14,1", model.PlatformIOS},
+		{"Macmini9,1", model.PlatformMacOS},
+		{"AppleTV11,1", model.PlatformTvOS},
+		{"Watch7,1", model.PlatformWatchOS},
+		{"RealityDevice14,1", model.PlatformVisionOS},
+	}
+	for _, tc := range cases {
+		inf := &info.Info{
+			Plists: &plist.Plists{
+				BuildManifest: &plist.BuildManifest{SupportedProductTypes: []string{tc.device}},
+			},
+		}
+		if got := platformFromInfo(inf); got != tc.want {
+			t.Errorf("platformFromInfo(%s) = %v, want %v", tc.device, got, tc.want)
+		}
+	}
+}

--- a/internal/syms/syms.go
+++ b/internal/syms/syms.go
@@ -10,12 +10,13 @@ import (
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho"
 	"github.com/blacktop/go-macho/types"
-	"github.com/blacktop/ipsw/internal/commands/dsc"
 	"github.com/blacktop/ipsw/internal/commands/extract"
+	"github.com/blacktop/ipsw/internal/commands/mount"
 	"github.com/blacktop/ipsw/internal/db"
 	"github.com/blacktop/ipsw/internal/model"
 	"github.com/blacktop/ipsw/internal/search"
 	"github.com/blacktop/ipsw/internal/utils"
+	"github.com/blacktop/ipsw/pkg/dyld"
 	"github.com/blacktop/ipsw/pkg/info"
 	"github.com/blacktop/ipsw/pkg/kernelcache"
 	"github.com/blacktop/ipsw/pkg/signature"
@@ -25,6 +26,16 @@ const (
 	highestBitMask uint64 = ^uint64(1 << 63)
 	isKernelMask   uint64 = 1 << 62
 )
+
+// scanConfig selects which sources of an IPSW a scan walks.
+type scanConfig struct {
+	IPSW       string
+	PemDB      string
+	SigsDir    string
+	Kernel     bool
+	DSC        bool
+	FileSystem bool
+}
 
 // scanImage is a single Mach-O image surfaced while scanning an IPSW, paired
 // with the extra metadata the streaming JSONL emitter needs but the persisted
@@ -296,86 +307,100 @@ func scanKernels(ipswPath, sigDir string, visit scanVisitor) error {
 	return nil
 }
 
-// scanDSCs opens every dyld_shared_cache in the IPSW and visits a "dsc"
-// container (carrying shared_region_start) followed by each of its dylib images.
-func scanDSCs(ipswPath, pemDB string, visit scanVisitor) error {
-	ctx, fs, err := dsc.OpenFromIPSW(ipswPath, pemDB, false, true)
+// scanDSCsInMount finds every dyld_shared_cache in an already-mounted volume and
+// visits a "dsc" container (carrying shared_region_start) followed by each of its
+// dylib images. The mount is provided by the caller so the volume is mounted once
+// and shared with the file-system Mach-O walk.
+func scanDSCsInMount(mountPoint string, visit scanVisitor) error {
+	dscPaths, err := dyld.GetDscPathsInMount(mountPoint, false, true)
 	if err != nil {
-		return fmt.Errorf("failed to open DSC from IPSW: %w", err)
+		return fmt.Errorf("failed to find DSCs in %s: %w", mountPoint, err)
 	}
-	defer func() {
-		for _, f := range fs {
-			f.Close()
+	for _, dscPath := range dscPaths {
+		if len(filepath.Ext(dscPath)) != 0 {
+			continue // skip subcaches/.symbols; dyld.Open pulls them in
 		}
-		ctx.Unmount()
-	}()
-
-	for _, f := range fs {
-		if err := visit(&scanImage{
-			Kind:              "dsc",
-			DSCUUID:           f.UUID.String(),
-			SharedRegionStart: f.Headers[f.UUID].SharedRegionStart,
-		}); err != nil {
+		f, err := dyld.Open(dscPath)
+		if err != nil {
+			return fmt.Errorf("failed to open DSC %s: %w", dscPath, err)
+		}
+		if err := scanDSC(f, visit); err != nil {
+			f.Close()
 			return err
 		}
+		f.Close()
+	}
+	return nil
+}
 
-		for idx, img := range f.Images {
-			log.WithFields(log.Fields{
-				"index": idx,
-				"name":  img.Name,
-			}).Debug("Parsing DSC Image")
-			img.ParsePublicSymbols(false)
-			img.ParseLocalSymbols(false)
-			m, err := img.GetMacho()
-			if err != nil {
-				return fmt.Errorf("failed to parse dyld_shared_cache image: %w", err)
-			}
-			defer m.Close()
-			dylib := &model.Macho{
-				UUID: m.UUID().String(),
-				Path: model.Path{Path: img.Name},
-			}
-			if text := m.Segment("__TEXT"); text != nil {
-				dylib.TextStart = text.Addr
-				dylib.TextEnd = text.Addr + text.Filesz
-			}
-			for _, fn := range m.GetFunctions() {
-				var msym *model.Symbol
-				if sym, ok := f.AddressToSymbol.Get(fn.StartAddr); ok {
-					msym = &model.Symbol{
-						Name:  model.Name{Name: sym},
-						Start: fn.StartAddr,
-						End:   fn.EndAddr,
-					}
-				} else {
-					msym = &model.Symbol{
-						Name:  model.Name{Name: fmt.Sprintf("func_%x", fn.StartAddr)},
-						Start: fn.StartAddr,
-						End:   fn.EndAddr,
-					}
+func scanDSC(f *dyld.File, visit scanVisitor) error {
+	if err := visit(&scanImage{
+		Kind:              "dsc",
+		DSCUUID:           f.UUID.String(),
+		SharedRegionStart: f.Headers[f.UUID].SharedRegionStart,
+	}); err != nil {
+		return err
+	}
+
+	for idx, img := range f.Images {
+		log.WithFields(log.Fields{
+			"index": idx,
+			"name":  img.Name,
+		}).Debug("Parsing DSC Image")
+		img.ParsePublicSymbols(false)
+		img.ParseLocalSymbols(false)
+		m, err := img.GetMacho()
+		if err != nil {
+			return fmt.Errorf("failed to parse dyld_shared_cache image: %w", err)
+		}
+		dylib := &model.Macho{
+			UUID: m.UUID().String(),
+			Path: model.Path{Path: img.Name},
+		}
+		if text := m.Segment("__TEXT"); text != nil {
+			dylib.TextStart = text.Addr
+			dylib.TextEnd = text.Addr + text.Filesz
+		}
+		for _, fn := range m.GetFunctions() {
+			var msym *model.Symbol
+			if sym, ok := f.AddressToSymbol.Get(fn.StartAddr); ok {
+				msym = &model.Symbol{
+					Name:  model.Name{Name: sym},
+					Start: fn.StartAddr,
+					End:   fn.EndAddr,
 				}
-				dylib.Symbols = append(dylib.Symbols, msym)
+			} else {
+				msym = &model.Symbol{
+					Name:  model.Name{Name: fmt.Sprintf("func_%x", fn.StartAddr)},
+					Start: fn.StartAddr,
+					End:   fn.EndAddr,
+				}
 			}
-			if err := visit(&scanImage{
-				Macho:   dylib,
-				Kind:    "dylib",
-				CPU:     machoArch(m),
-				Arch:    machoArch(m),
-				DSCUUID: f.UUID.String(),
-			}); err != nil {
-				return err
-			}
+			dylib.Symbols = append(dylib.Symbols, msym)
+		}
+		if err := visit(&scanImage{
+			Macho:   dylib,
+			Kind:    "dylib",
+			CPU:     machoArch(m),
+			Arch:    machoArch(m),
+			DSCUUID: f.UUID.String(),
+		}); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-// scanFileSystem walks every Mach-O in the IPSW file system and visits it as a
-// "macho" image.
-func scanFileSystem(ipswPath, pemDB string, visit scanVisitor) error {
-	return search.ForEachMachoInIPSW(ipswPath, pemDB, func(path string, m *macho.File) error {
+// scanMachosInMount walks every Mach-O in an already-mounted volume and visits
+// it as a "macho" image. The path is reported relative to the mount point so it
+// matches the path the daemon database stores.
+func scanMachosInMount(mountPoint string, visit scanVisitor) error {
+	return search.ForEachMacho(mountPoint, func(path string, m *macho.File) error {
 		if m.UUID() == nil {
 			return nil
+		}
+		if _, rest, ok := strings.Cut(path, mountPoint); ok {
+			path = rest
 		}
 		mm := &model.Macho{
 			UUID: m.UUID().String(),
@@ -414,6 +439,68 @@ func scanFileSystem(ipswPath, pemDB string, visit scanVisitor) error {
 	})
 }
 
+// scanIPSW walks the requested sources of an IPSW and emits each image to visit.
+//
+// The kernelcache comes from the IPSW zip (no mount). The DSC parse and the
+// file-system Mach-O walk both live on the SystemOS volume, so it is mounted
+// once via a mount.Session and reused; the remaining OS volumes are mounted once
+// each. Each distinct volume is therefore extracted/decrypted/mounted a single
+// time per scan.
+func scanIPSW(cfg *scanConfig, visit scanVisitor) error {
+	if cfg.Kernel {
+		if err := scanKernels(cfg.IPSW, cfg.SigsDir, visit); err != nil {
+			return fmt.Errorf("failed to scan kernels: %w", err)
+		}
+	}
+	if !cfg.DSC && !cfg.FileSystem {
+		return nil
+	}
+
+	session := mount.NewSession(cfg.IPSW, &mount.Config{PemDB: cfg.PemDB})
+	defer func() {
+		if err := session.Close(); err != nil {
+			log.WithError(err).Debug("failed to unmount IPSW DMGs")
+		}
+	}()
+
+	walked := make(map[string]bool)
+	walk := func(mountPoint string) error {
+		if walked[mountPoint] {
+			return nil // a volume aliased to one already walked (e.g. sys==fs)
+		}
+		walked[mountPoint] = true
+		return scanMachosInMount(mountPoint, visit)
+	}
+
+	// The SystemOS volume hosts both the DSC and most framework Mach-Os; mount
+	// it once and run both passes against it.
+	sysMount, err := session.Root("sys")
+	if err != nil {
+		return fmt.Errorf("failed to mount SystemOS: %w", err)
+	}
+	if cfg.DSC {
+		if err := scanDSCsInMount(sysMount, visit); err != nil {
+			return fmt.Errorf("failed to scan DSCs: %w", err)
+		}
+	}
+	if cfg.FileSystem {
+		if err := walk(sysMount); err != nil {
+			return fmt.Errorf("failed to scan SystemOS machos: %w", err)
+		}
+		for _, typ := range []string{"fs", "app", "exc"} {
+			mountPoint, err := session.Root(typ)
+			if err != nil {
+				log.WithError(err).Debugf("skipping %s volume", typ)
+				continue
+			}
+			if err := walk(mountPoint); err != nil {
+				return fmt.Errorf("failed to scan %s machos: %w", typ, err)
+			}
+		}
+	}
+	return nil
+}
+
 // Scan scans the IPSW file and extracts information about the kernels, DSCs, and file system.
 func Scan(ipswPath, pemDB, sigsDir string, db db.Database) (err error) {
 	/* IPSW */
@@ -444,17 +531,15 @@ func Scan(ipswPath, pemDB, sigsDir string, db db.Database) (err error) {
 	}
 
 	acc := newDBAccumulator(ipsw)
-	/* KERNEL */
-	if err := scanKernels(ipswPath, sigsDir, acc.visit); err != nil {
-		return fmt.Errorf("failed to scan kernels: %w", err)
-	}
-	/* DSC */
-	if err := scanDSCs(ipswPath, pemDB, acc.visit); err != nil {
-		return fmt.Errorf("failed to scan DSCs: %w", err)
-	}
-	/* FileSystem */
-	if err := scanFileSystem(ipswPath, pemDB, acc.visit); err != nil {
-		return fmt.Errorf("failed to search for machos in IPSW: %w", err)
+	if err := scanIPSW(&scanConfig{
+		IPSW:       ipswPath,
+		PemDB:      pemDB,
+		SigsDir:    sigsDir,
+		Kernel:     true,
+		DSC:        true,
+		FileSystem: true,
+	}, acc.visit); err != nil {
+		return err
 	}
 
 	log.Debug("Saving IPSW with FileSystem")
@@ -478,17 +563,15 @@ func Rescan(ipswPath, pemDB, sigsDir string, db db.Database) (err error) {
 	ipsw.DSCs = nil
 	ipsw.FileSystem = nil
 	acc := newDBAccumulator(ipsw)
-	/* KERNEL */
-	if err := scanKernels(ipswPath, sigsDir, acc.visit); err != nil {
-		return fmt.Errorf("failed to scan kernels: %w", err)
-	}
-	/* DSC */
-	if err := scanDSCs(ipswPath, pemDB, acc.visit); err != nil {
-		return fmt.Errorf("failed to scan DSCs: %w", err)
-	}
-	/* FileSystem */
-	if err := scanFileSystem(ipswPath, pemDB, acc.visit); err != nil {
-		return fmt.Errorf("failed to search for machos in IPSW: %w", err)
+	if err := scanIPSW(&scanConfig{
+		IPSW:       ipswPath,
+		PemDB:      pemDB,
+		SigsDir:    sigsDir,
+		Kernel:     true,
+		DSC:        true,
+		FileSystem: true,
+	}, acc.visit); err != nil {
+		return err
 	}
 
 	log.Debug("Saving IPSW with FileSystem")

--- a/internal/syms/syms.go
+++ b/internal/syms/syms.go
@@ -1,6 +1,7 @@
 package syms
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -50,6 +51,7 @@ type scanImage struct {
 	Arch              string       // lowercase arch slice, e.g. "arm64e"
 	DSCUUID           string       // parent DSC UUID ("dsc" + "dylib")
 	SharedRegionStart uint64       // parent DSC shared region start ("dsc")
+	IsFileset         bool         // kernel image is a fileset container, not a loadable kernel Mach-O
 	KernelUUID        string       // parent kernelcache UUID ("kext")
 	KernelVersion     string       // kernelcache version ("kernel")
 }
@@ -96,7 +98,7 @@ func (a *dbAccumulator) visit(img *scanImage) error {
 			a.ipsw.Kernels = append(a.ipsw.Kernels, kc)
 		}
 		// A non-fileset kernel is both the cache container and its only kext.
-		if len(img.Macho.Symbols) > 0 {
+		if !img.IsFileset {
 			kc.Kexts = append(kc.Kexts, img.Macho)
 		}
 	case "kext":
@@ -258,6 +260,7 @@ func scanKernels(ipswPath, sigDir string, visit scanVisitor) error {
 				Kind:          "kernel",
 				CPU:           arch,
 				Arch:          arch,
+				IsFileset:     true,
 				KernelVersion: kv.String(),
 			}); err != nil {
 				return err
@@ -439,6 +442,41 @@ func scanMachosInMount(mountPoint string, visit scanVisitor) error {
 	})
 }
 
+func optionalVolumePresent(inf *info.Info, typ string) (bool, error) {
+	var err error
+	switch typ {
+	case "fs":
+		_, err = inf.GetFileSystemOsDmg()
+	case "app":
+		_, err = inf.GetAppOsDmg()
+	case "exc":
+		_, err = inf.GetExclaveOSDmg()
+	default:
+		return false, fmt.Errorf("unknown optional volume type: %s", typ)
+	}
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, info.ErrorCryptexNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+func rescanTarget(existing *model.Ipsw) *model.Ipsw {
+	return &model.Ipsw{
+		ID:        existing.ID,
+		Name:      existing.Name,
+		Version:   existing.Version,
+		BuildID:   existing.BuildID,
+		Platform:  existing.Platform,
+		Devices:   slices.Clone(existing.Devices),
+		CreatedAt: existing.CreatedAt,
+		UpdatedAt: existing.UpdatedAt,
+		DeletedAt: existing.DeletedAt,
+	}
+}
+
 // scanIPSW walks the requested sources of an IPSW and emits each image to visit.
 //
 // The kernelcache comes from the IPSW zip (no mount). The DSC parse and the
@@ -454,6 +492,15 @@ func scanIPSW(cfg *scanConfig, visit scanVisitor) error {
 	}
 	if !cfg.DSC && !cfg.FileSystem {
 		return nil
+	}
+
+	var inf *info.Info
+	if cfg.FileSystem {
+		var err error
+		inf, err = info.Parse(cfg.IPSW)
+		if err != nil {
+			return fmt.Errorf("failed to parse IPSW info: %w", err)
+		}
 	}
 
 	session := mount.NewSession(cfg.IPSW, &mount.Config{PemDB: cfg.PemDB})
@@ -488,10 +535,17 @@ func scanIPSW(cfg *scanConfig, visit scanVisitor) error {
 			return fmt.Errorf("failed to scan SystemOS machos: %w", err)
 		}
 		for _, typ := range []string{"fs", "app", "exc"} {
+			present, err := optionalVolumePresent(inf, typ)
+			if err != nil {
+				return fmt.Errorf("failed to inspect %s volume: %w", typ, err)
+			}
+			if !present {
+				log.Debugf("skipping absent %s volume", typ)
+				continue
+			}
 			mountPoint, err := session.Root(typ)
 			if err != nil {
-				log.WithError(err).Debugf("skipping %s volume", typ)
-				continue
+				return fmt.Errorf("failed to mount %s volume: %w", typ, err)
 			}
 			if err := walk(mountPoint); err != nil {
 				return fmt.Errorf("failed to scan %s machos: %w", typ, err)
@@ -558,10 +612,9 @@ func Rescan(ipswPath, pemDB, sigsDir string, db db.Database) (err error) {
 		return fmt.Errorf("failed to get IPSW from database: %w", err)
 	}
 	// The kernel, DSC, and file system graphs are rebuilt from scratch on
-	// rescan; clear them so a re-scan replaces rather than duplicates entries.
-	ipsw.Kernels = nil
-	ipsw.DSCs = nil
-	ipsw.FileSystem = nil
+	// rescan. Build the replacement graph separately so an in-memory database
+	// keeps the old graph intact if scanning fails before Save.
+	ipsw = rescanTarget(ipsw)
 	acc := newDBAccumulator(ipsw)
 	if err := scanIPSW(&scanConfig{
 		IPSW:       ipswPath,

--- a/internal/syms/syms.go
+++ b/internal/syms/syms.go
@@ -472,9 +472,11 @@ func Rescan(ipswPath, pemDB, sigsDir string, db db.Database) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to get IPSW from database: %w", err)
 	}
-	// Kernels and DSCs are rebuilt from scratch on rescan.
+	// The kernel, DSC, and file system graphs are rebuilt from scratch on
+	// rescan; clear them so a re-scan replaces rather than duplicates entries.
 	ipsw.Kernels = nil
 	ipsw.DSCs = nil
+	ipsw.FileSystem = nil
 	acc := newDBAccumulator(ipsw)
 	/* KERNEL */
 	if err := scanKernels(ipswPath, sigsDir, acc.visit); err != nil {

--- a/internal/syms/syms.go
+++ b/internal/syms/syms.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/apex/log"
 	"github.com/blacktop/go-macho"
@@ -24,6 +25,82 @@ const (
 	highestBitMask uint64 = ^uint64(1 << 63)
 	isKernelMask   uint64 = 1 << 62
 )
+
+// scanImage is a single Mach-O image surfaced while scanning an IPSW, paired
+// with the extra metadata the streaming JSONL emitter needs but the persisted
+// model does not carry (arch/cpu, parent DSC/kernelcache identity).
+//
+// Macho is normalized exactly as the daemon database stores it, so the symbol
+// start/end values are byte-identical whether they are persisted or streamed.
+type scanImage struct {
+	Macho             *model.Macho // nil for a "dsc" container event
+	Kind              string       // "dsc", "dylib", "kext", "kernel", or "macho"
+	CPU               string       // lowercase arch slice, e.g. "arm64e"
+	Arch              string       // lowercase arch slice, e.g. "arm64e"
+	DSCUUID           string       // parent DSC UUID ("dsc" + "dylib")
+	SharedRegionStart uint64       // parent DSC shared region start ("dsc")
+	KernelUUID        string       // parent kernelcache UUID ("kext")
+	KernelVersion     string       // kernelcache version ("kernel")
+}
+
+// scanVisitor is invoked once per image (and once per DSC container) as an IPSW
+// is walked. Returning an error aborts the scan.
+type scanVisitor func(*scanImage) error
+
+// dbAccumulator is a scanVisitor that rebuilds the nested model graph the daemon
+// database persists, preserving the exact structure the previous Scan produced.
+type dbAccumulator struct {
+	ipsw *model.Ipsw
+	dscs map[string]*model.DyldSharedCache
+	kcs  map[string]*model.Kernelcache
+}
+
+func newDBAccumulator(ipsw *model.Ipsw) *dbAccumulator {
+	return &dbAccumulator{
+		ipsw: ipsw,
+		dscs: make(map[string]*model.DyldSharedCache),
+		kcs:  make(map[string]*model.Kernelcache),
+	}
+}
+
+func (a *dbAccumulator) visit(img *scanImage) error {
+	switch img.Kind {
+	case "dsc":
+		if _, ok := a.dscs[img.DSCUUID]; !ok {
+			cache := &model.DyldSharedCache{UUID: img.DSCUUID, SharedRegionStart: img.SharedRegionStart}
+			a.dscs[img.DSCUUID] = cache
+			a.ipsw.DSCs = append(a.ipsw.DSCs, cache)
+		}
+	case "dylib":
+		cache, ok := a.dscs[img.DSCUUID]
+		if !ok {
+			return fmt.Errorf("dylib %s references unknown DSC %s", img.Macho.UUID, img.DSCUUID)
+		}
+		cache.Images = append(cache.Images, img.Macho)
+	case "kernel":
+		kc, ok := a.kcs[img.Macho.UUID]
+		if !ok {
+			kc = &model.Kernelcache{UUID: img.Macho.UUID, Version: img.KernelVersion}
+			a.kcs[img.Macho.UUID] = kc
+			a.ipsw.Kernels = append(a.ipsw.Kernels, kc)
+		}
+		// A non-fileset kernel is both the cache container and its only kext.
+		if len(img.Macho.Symbols) > 0 {
+			kc.Kexts = append(kc.Kexts, img.Macho)
+		}
+	case "kext":
+		kc, ok := a.kcs[img.KernelUUID]
+		if !ok {
+			return fmt.Errorf("kext %s references unknown kernelcache %s", img.Macho.UUID, img.KernelUUID)
+		}
+		kc.Kexts = append(kc.Kexts, img.Macho)
+	case "macho":
+		a.ipsw.FileSystem = append(a.ipsw.FileSystem, img.Macho)
+	default:
+		return fmt.Errorf("unknown scan image kind: %q", img.Kind)
+	}
+	return nil
+}
 
 func appendModelSymbol(dst *[]*model.Symbol, seen map[uint64]struct{}, addr, end uint64, name string) {
 	if name == "" || addr == 0 {
@@ -108,15 +185,23 @@ func collectKernelMachoSymbols(m *macho.File, smap signature.SymbolMap) []*model
 	return symbols
 }
 
-func scanKernels(ipswPath, sigDir string) ([]*model.Kernelcache, error) {
-	var kcs []*model.Kernelcache
+// machoArch returns the lowercase architecture slice (e.g. "arm64e") for a
+// Mach-O, matching the short form used elsewhere in the CLI.
+func machoArch(m *macho.File) string {
+	return strings.ToLower(m.SubCPU.String(m.CPU))
+}
+
+// scanKernels extracts every kernelcache from the IPSW and visits the cache
+// container plus each of its KEXTs. Kernel and KEXT symbol addresses are
+// bit-63-cleared (highestBitMask) exactly as the daemon database stores them.
+func scanKernels(ipswPath, sigDir string, visit scanVisitor) error {
 	var sigs []signature.Symbolicator
 
 	if sigDir != "" {
 		var err error
 		sigs, err = signature.Parse(sigDir)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse signatures: %v", err)
+			return fmt.Errorf("failed to parse signatures: %v", err)
 		}
 	}
 
@@ -125,7 +210,7 @@ func scanKernels(ipswPath, sigDir string) ([]*model.Kernelcache, error) {
 		Output: os.TempDir(),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract kernelcache: %w", err)
+		return fmt.Errorf("failed to extract kernelcache: %w", err)
 	}
 	defer func() {
 		for k := range out {
@@ -135,23 +220,37 @@ func scanKernels(ipswPath, sigDir string) ([]*model.Kernelcache, error) {
 	for k := range out {
 		smap := signature.NewSymbolMap()
 		if err := smap.Symbolicate(k, sigs, true); err != nil {
-			return nil, fmt.Errorf("failed to symbolicate kernelcache: %v", err)
+			return fmt.Errorf("failed to symbolicate kernelcache: %v", err)
 		}
 
 		m, err := macho.Open(k)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open kernel: %w", err)
+			return fmt.Errorf("failed to open kernel: %w", err)
 		}
 		defer m.Close()
 		kv, err := kernelcache.GetVersion(m)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		kc := &model.Kernelcache{
-			UUID:    m.UUID().String(),
-			Version: kv.String(),
+		arch := machoArch(m)
+		container := &model.Macho{
+			UUID: m.UUID().String(),
+			Path: model.Path{Path: filepath.Base(k)},
+		}
+		if text := m.Segment("__TEXT"); text != nil {
+			container.TextStart = text.Addr & highestBitMask
+			container.TextEnd = (text.Addr + text.Filesz) & highestBitMask
 		}
 		if m.FileTOC.FileHeader.Type == types.MH_FILESET {
+			if err := visit(&scanImage{
+				Macho:         container,
+				Kind:          "kernel",
+				CPU:           arch,
+				Arch:          arch,
+				KernelVersion: kv.String(),
+			}); err != nil {
+				return err
+			}
 			for idx, fe := range m.FileSets() {
 				log.WithFields(log.Fields{
 					"index": idx,
@@ -159,7 +258,7 @@ func scanKernels(ipswPath, sigDir string) ([]*model.Kernelcache, error) {
 				}).Debug("Parsing Kernel Kext")
 				mfe, err := m.GetFileSetFileByName(fe.EntryID)
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse entry %s: %v", fe.EntryID, err)
+					return fmt.Errorf("failed to parse entry %s: %v", fe.EntryID, err)
 				}
 				kext := &model.Macho{
 					Path: model.Path{Path: fe.EntryID},
@@ -170,30 +269,39 @@ func scanKernels(ipswPath, sigDir string) ([]*model.Kernelcache, error) {
 					kext.TextEnd = (text.Addr + text.Filesz) & highestBitMask
 				}
 				kext.Symbols = collectKernelMachoSymbols(mfe, smap)
-				kc.Kexts = append(kc.Kexts, kext)
+				if err := visit(&scanImage{
+					Macho:      kext,
+					Kind:       "kext",
+					CPU:        machoArch(mfe),
+					Arch:       machoArch(mfe),
+					KernelUUID: m.UUID().String(),
+				}); err != nil {
+					return err
+				}
 			}
 		} else {
-			kext := &model.Macho{
-				Path: model.Path{Path: filepath.Base(k)},
-				UUID: m.UUID().String(),
+			container.Symbols = collectKernelMachoSymbols(m, smap)
+			if err := visit(&scanImage{
+				Macho:         container,
+				Kind:          "kernel",
+				CPU:           arch,
+				Arch:          arch,
+				KernelVersion: kv.String(),
+			}); err != nil {
+				return err
 			}
-			if text := m.Segment("__TEXT"); text != nil {
-				kext.TextStart = text.Addr & highestBitMask
-				kext.TextEnd = (text.Addr + text.Filesz) & highestBitMask
-			}
-			kext.Symbols = collectKernelMachoSymbols(m, smap)
-			kc.Kexts = append(kc.Kexts, kext)
 		}
-		kcs = append(kcs, kc)
 	}
 
-	return kcs, nil
+	return nil
 }
 
-func scanDSCs(ipswPath, pemDB string) ([]*model.DyldSharedCache, error) {
+// scanDSCs opens every dyld_shared_cache in the IPSW and visits a "dsc"
+// container (carrying shared_region_start) followed by each of its dylib images.
+func scanDSCs(ipswPath, pemDB string, visit scanVisitor) error {
 	ctx, fs, err := dsc.OpenFromIPSW(ipswPath, pemDB, false, true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open DSC from IPSW: %w", err)
+		return fmt.Errorf("failed to open DSC from IPSW: %w", err)
 	}
 	defer func() {
 		for _, f := range fs {
@@ -202,12 +310,13 @@ func scanDSCs(ipswPath, pemDB string) ([]*model.DyldSharedCache, error) {
 		ctx.Unmount()
 	}()
 
-	var dscs []*model.DyldSharedCache
-
 	for _, f := range fs {
-		dsc := &model.DyldSharedCache{
-			UUID:              f.UUID.String(),
+		if err := visit(&scanImage{
+			Kind:              "dsc",
+			DSCUUID:           f.UUID.String(),
 			SharedRegionStart: f.Headers[f.UUID].SharedRegionStart,
+		}); err != nil {
+			return err
 		}
 
 		for idx, img := range f.Images {
@@ -219,7 +328,7 @@ func scanDSCs(ipswPath, pemDB string) ([]*model.DyldSharedCache, error) {
 			img.ParseLocalSymbols(false)
 			m, err := img.GetMacho()
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse dyld_shared_cache image: %w", err)
+				return fmt.Errorf("failed to parse dyld_shared_cache image: %w", err)
 			}
 			defer m.Close()
 			dylib := &model.Macho{
@@ -247,12 +356,62 @@ func scanDSCs(ipswPath, pemDB string) ([]*model.DyldSharedCache, error) {
 				}
 				dylib.Symbols = append(dylib.Symbols, msym)
 			}
-			dsc.Images = append(dsc.Images, dylib)
+			if err := visit(&scanImage{
+				Macho:   dylib,
+				Kind:    "dylib",
+				CPU:     machoArch(m),
+				Arch:    machoArch(m),
+				DSCUUID: f.UUID.String(),
+			}); err != nil {
+				return err
+			}
 		}
-
-		dscs = append(dscs, dsc)
 	}
-	return dscs, nil
+	return nil
+}
+
+// scanFileSystem walks every Mach-O in the IPSW file system and visits it as a
+// "macho" image.
+func scanFileSystem(ipswPath, pemDB string, visit scanVisitor) error {
+	return search.ForEachMachoInIPSW(ipswPath, pemDB, func(path string, m *macho.File) error {
+		if m.UUID() == nil {
+			return nil
+		}
+		mm := &model.Macho{
+			UUID: m.UUID().String(),
+			Path: model.Path{Path: path},
+		}
+		if text := m.Segment("__TEXT"); text != nil {
+			mm.TextStart = text.Addr
+			mm.TextEnd = text.Addr + text.Filesz
+		}
+		for _, fn := range m.GetFunctions() {
+			var msym *model.Symbol
+			if syms, err := m.FindAddressSymbols(fn.StartAddr); err == nil {
+				for _, sym := range syms {
+					fn.Name = sym.Name
+				}
+				msym = &model.Symbol{
+					Name:  model.Name{Name: fn.Name},
+					Start: fn.StartAddr,
+					End:   fn.EndAddr,
+				}
+			} else {
+				msym = &model.Symbol{
+					Name:  model.Name{Name: fmt.Sprintf("func_%x", fn.StartAddr)},
+					Start: fn.StartAddr,
+					End:   fn.EndAddr,
+				}
+			}
+			mm.Symbols = append(mm.Symbols, msym)
+		}
+		return visit(&scanImage{
+			Macho: mm,
+			Kind:  "macho",
+			CPU:   machoArch(m),
+			Arch:  machoArch(m),
+		})
+	})
 }
 
 // Scan scans the IPSW file and extracts information about the kernels, DSCs, and file system.
@@ -284,49 +443,17 @@ func Scan(ipswPath, pemDB, sigsDir string, db db.Database) (err error) {
 		return fmt.Errorf("failed to save IPSW to database: %w", err)
 	}
 
+	acc := newDBAccumulator(ipsw)
 	/* KERNEL */
-	if ipsw.Kernels, err = scanKernels(ipswPath, sigsDir); err != nil {
+	if err := scanKernels(ipswPath, sigsDir, acc.visit); err != nil {
 		return fmt.Errorf("failed to scan kernels: %w", err)
 	}
 	/* DSC */
-	if ipsw.DSCs, err = scanDSCs(ipswPath, pemDB); err != nil {
+	if err := scanDSCs(ipswPath, pemDB, acc.visit); err != nil {
 		return fmt.Errorf("failed to scan DSCs: %w", err)
 	}
 	/* FileSystem */
-	if err := search.ForEachMachoInIPSW(ipswPath, pemDB, func(path string, m *macho.File) error {
-		if m.UUID() != nil {
-			mm := &model.Macho{
-				UUID: m.UUID().String(),
-				Path: model.Path{Path: path},
-			}
-			if text := m.Segment("__TEXT"); text != nil {
-				mm.TextStart = text.Addr
-				mm.TextEnd = text.Addr + text.Filesz
-			}
-			for _, fn := range m.GetFunctions() {
-				var msym *model.Symbol
-				if syms, err := m.FindAddressSymbols(fn.StartAddr); err == nil {
-					for _, sym := range syms {
-						fn.Name = sym.Name
-					}
-					msym = &model.Symbol{
-						Name:  model.Name{Name: fn.Name},
-						Start: fn.StartAddr,
-						End:   fn.EndAddr,
-					}
-				} else {
-					msym = &model.Symbol{
-						Name:  model.Name{Name: fmt.Sprintf("func_%x", fn.StartAddr)},
-						Start: fn.StartAddr,
-						End:   fn.EndAddr,
-					}
-				}
-				mm.Symbols = append(mm.Symbols, msym)
-			}
-			ipsw.FileSystem = append(ipsw.FileSystem, mm)
-		}
-		return nil
-	}); err != nil {
+	if err := scanFileSystem(ipswPath, pemDB, acc.visit); err != nil {
 		return fmt.Errorf("failed to search for machos in IPSW: %w", err)
 	}
 
@@ -345,49 +472,20 @@ func Rescan(ipswPath, pemDB, sigsDir string, db db.Database) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to get IPSW from database: %w", err)
 	}
+	// Kernels and DSCs are rebuilt from scratch on rescan.
+	ipsw.Kernels = nil
+	ipsw.DSCs = nil
+	acc := newDBAccumulator(ipsw)
 	/* KERNEL */
-	if ipsw.Kernels, err = scanKernels(ipswPath, sigsDir); err != nil {
+	if err := scanKernels(ipswPath, sigsDir, acc.visit); err != nil {
 		return fmt.Errorf("failed to scan kernels: %w", err)
 	}
 	/* DSC */
-	if ipsw.DSCs, err = scanDSCs(ipswPath, pemDB); err != nil {
+	if err := scanDSCs(ipswPath, pemDB, acc.visit); err != nil {
 		return fmt.Errorf("failed to scan DSCs: %w", err)
 	}
 	/* FileSystem */
-	if err := search.ForEachMachoInIPSW(ipswPath, pemDB, func(path string, m *macho.File) error {
-		if m.UUID() != nil {
-			mm := &model.Macho{
-				UUID: m.UUID().String(),
-				Path: model.Path{Path: path},
-			}
-			if text := m.Segment("__TEXT"); text != nil {
-				mm.TextStart = text.Addr
-				mm.TextEnd = text.Addr + text.Filesz
-			}
-			for _, fn := range m.GetFunctions() {
-				var msym *model.Symbol
-				if syms, err := m.FindAddressSymbols(fn.StartAddr); err == nil {
-					for _, sym := range syms {
-						fn.Name = sym.Name
-					}
-					msym = &model.Symbol{
-						Name:  model.Name{Name: fn.Name},
-						Start: fn.StartAddr,
-						End:   fn.EndAddr,
-					}
-				} else {
-					msym = &model.Symbol{
-						Name:  model.Name{Name: fmt.Sprintf("func_%x", fn.StartAddr)},
-						Start: fn.StartAddr,
-						End:   fn.EndAddr,
-					}
-				}
-				mm.Symbols = append(mm.Symbols, msym)
-			}
-			ipsw.FileSystem = append(ipsw.FileSystem, mm)
-		}
-		return nil
-	}); err != nil {
+	if err := scanFileSystem(ipswPath, pemDB, acc.visit); err != nil {
 		return fmt.Errorf("failed to search for machos in IPSW: %w", err)
 	}
 

--- a/internal/syms/syms.go
+++ b/internal/syms/syms.go
@@ -319,6 +319,11 @@ func scanDSCsInMount(mountPoint string, visit scanVisitor) error {
 	if err != nil {
 		return fmt.Errorf("failed to find DSCs in %s: %w", mountPoint, err)
 	}
+	if len(dscPaths) == 0 {
+		// DSC scanning was requested but the volume has none; surface it rather
+		// than silently emitting zero dylib symbols.
+		log.Warnf("no dyld_shared_cache found in %s", mountPoint)
+	}
 	for _, dscPath := range dscPaths {
 		if len(filepath.Ext(dscPath)) != 0 {
 			continue // skip subcaches/.symbols; dyld.Open pulls them in

--- a/www/docs/cli/ipsw/diff.md
+++ b/www/docs/cli/ipsw/diff.md
@@ -48,6 +48,7 @@ ipsw diff <IPSW|OTA|DIR> <IPSW|OTA|DIR> [flags]
       --key-db string        Path to AEA keys JSON database (for OTA diffs)
       --key-val string       Base64 encoded AEA symmetric encryption key (for OTA diffs)
       --launchd              Diff launchd configs
+      --loc                  Diff localized string resources (.strings, .stringsdict, .loctable)
       --low-memory           Use disk caching to reduce RAM usage
   -m, --markdown             Output diff as Markdown
   -o, --output string        Folder to save diff output

--- a/www/docs/cli/ipsw/ipsw.md
+++ b/www/docs/cli/ipsw/ipsw.md
@@ -53,6 +53,7 @@ Download and Parse IPSWs (and SO much more)
 * [ipsw ssh](/docs/cli/ipsw/ssh)	 - SSH into a jailbroken device
 * [ipsw swift-dump](/docs/cli/ipsw/swift-dump)	 - 🚧 Swift class-dump a dylib from a DSC or MachO
 * [ipsw symbolicate](/docs/cli/ipsw/symbolicate)	 - Symbolicate ARM 64-bit crash logs (similar to Apple's symbolicatecrash)
+* [ipsw symbols](/docs/cli/ipsw/symbols)	 - Emit IPSW symbols as JSONL
 * [ipsw version](/docs/cli/ipsw/version)	 - Print the version number of ipsw
 * [ipsw watch](/docs/cli/ipsw/watch)	 - Watch Github Commits
 

--- a/www/docs/cli/ipsw/kernel/symbolicate.md
+++ b/www/docs/cli/ipsw/kernel/symbolicate.md
@@ -14,6 +14,17 @@ Symbolicate kernelcache
 ipsw kernel symbolicate [flags]
 ```
 
+### Examples
+
+```bash
+# Symbolicate a kernelcache using signatures and write the map to JSON
+❯ ipsw kernel symbolicate --signatures /path/to/sigs --json kernelcache.release.iPhone18,1
+# Look up the nearest symbol for an address directly from a kernelcache
+❯ ipsw kernel symbolicate --signatures /path/to/sigs --lookup 0xfffffe000aecb258 kernelcache.release.iPhone18,1
+# Look up the nearest symbol using a previously generated symbol map
+❯ ipsw kernel symbolicate --lookup 0xfffffe000aecb258 kernelcache.release.iPhone18,1.symbols.json
+```
+
 ### Options
 
 ```
@@ -21,7 +32,7 @@ ipsw kernel symbolicate [flags]
   -f, --flat                Output results in flat file '.syms' format
   -h, --help                help for symbolicate
   -j, --json                Output results in JSON format
-  -l, --lookup uint         Lookup a symbol by address
+  -l, --lookup uint         Lookup the nearest symbol for an address (input may be a kernelcache or a symbols JSON map)
   -o, --output string       Folder to write files to
   -q, --quiet               Do NOT display logging
   -s, --signatures string   Path to signatures folder

--- a/www/docs/cli/ipsw/symbolicate.md
+++ b/www/docs/cli/ipsw/symbolicate.md
@@ -20,6 +20,11 @@ ipsw symbolicate <CRASHLOG> [IPSW|DSC] [flags]
 # Symbolicate a panic crashlog (BugType=210) with an IPSW
 ❯ ipsw symbolicate panic-full-2024-03-21-004704.000.ips iPad_Pro_HFR_17.4_21E219_Restore.ipsw
 
+# Symbolicate without an IPSW/DSC; falls back to the matching Xcode DeviceSupport DSC
+❯ ipsw symbolicate panic-full-2024-03-21-004704.000.ips
+  # Uses ~/Library/Developer/Xcode/<Platform> DeviceSupport/<device> (<build>)/Symbols
+  # (userspace frames only for panics; kernel frames still need an IPSW)
+
 # Show disassembly around panic frames with --peek (default 5 instructions)
 ❯ ipsw symbolicate panic.ips firmware.ipsw --peek
 

--- a/www/docs/cli/ipsw/symbols.md
+++ b/www/docs/cli/ipsw/symbols.md
@@ -1,0 +1,55 @@
+---
+id: symbols
+title: symbols
+hide_title: true
+hide_table_of_contents: true
+sidebar_label: symbols
+description: Emit IPSW symbols as JSONL
+---
+## ipsw symbols
+
+Emit IPSW symbols as JSONL
+
+### Synopsis
+
+Emit every symbol in an IPSW as newline-delimited JSON (JSONL).
+
+The stream is emitted in this order: one "ipsw" line, then for each image an
+"image" line immediately followed by that image's "symbol" lines. Each
+dyld_shared_cache also emits a one-time "dsc" line carrying shared_region_start,
+which its dylib images reference via dsc_uuid.
+
+Kernel and KEXT symbol addresses are bit-63-cleared exactly as the ipswd symbol
+database stores them, so a server backed by this output returns byte-identical
+results to the daemon.
+
+```
+ipsw symbols <IPSW> [flags]
+```
+
+### Options
+
+```
+      --dyld                Include dyld_shared_cache dylib symbols
+      --filesystem          Include file system Mach-O symbols
+  -h, --help                help for symbols
+      --json                Emit symbols as JSONL (one JSON object per line)
+      --kernel              Include kernelcache/KEXT symbols
+  -o, --output string       Output file path ("-" or unset for stdout)
+      --pem-db string       AEA pem DB JSON file
+      --signatures string   Path to kernel symbolication signatures directory
+```
+
+### Options inherited from parent commands
+
+```
+      --color           colorize output
+      --config string   config file (default is $HOME/.config/ipsw/config.yaml)
+      --no-color        disable colorize output
+  -V, --verbose         verbose output
+```
+
+### SEE ALSO
+
+* [ipsw](/docs/cli/ipsw)	 - Download and Parse IPSWs (and SO much more)
+


### PR DESCRIPTION
## What

Adds `ipsw symbols --json <IPSW>`, which streams every symbol in an IPSW as newline-delimited JSON (JSONL) for ingestion by an external symbol server.

```
ipsw symbols --json [--dyld] [--kernel] [--filesystem] [--signatures <dir>] [--pem-db <db>] [--output <path|->] <IPSW>
```

- `--dyld` / `--kernel` / `--filesystem` select sources (default: all on when none given).
- `--signatures` is the kernel symbolicator signatures dir; `--pem-db` is the AEA PEM db — the same inputs `syms.Scan` already uses.
- `--output` writes to a file; `-` or unset streams to stdout.

## Schema

One `ipsw` line, then for each image an `image` line immediately followed by its `symbol` lines. Each DSC emits a one-time `dsc` line; dylibs reference it via `dsc_uuid`.

```json
{"type":"ipsw","id":"<sha1>","name":"...","version":"26.5","build":"23F77","platform":"iOS","devices":["iPhone18,1"]}
{"type":"dsc","uuid":"<DSC-UUID>","shared_region_start":6442450944}
{"type":"image","uuid":"<UUID>","kind":"dylib","path":"/usr/lib/libobjc.A.dylib","text_start":...,"text_end":...,"cpu":"arm64e","arch":"arm64e","dsc_uuid":"<DSC-UUID>"}
{"type":"symbol","image_uuid":"<UUID>","name":"_objc_msgSend","start":...,"end":...}
{"type":"image","uuid":"<KERNEL-UUID>","kind":"kernel","path":"kernelcache...","text_start":...,"text_end":...,"cpu":"arm64e","arch":"arm64e","kernel_version":"Darwin Kernel Version 25.5.0..."}
{"type":"image","uuid":"<KEXT-UUID>","kind":"kext","path":"com.apple.kernel","text_start":...,"text_end":...,"cpu":"arm64e","arch":"arm64e"}
```

- `kind` ∈ {`dylib`,`kext`,`kernel`,`macho`}.
- `shared_region_start` is carried on a one-time `dsc` line (not repeated per dylib); each dylib links back via `dsc_uuid`.
- `text_start`/`text_end` = unslid `__TEXT` range. Kernel/KEXT values are bit-63-cleared (`highestBitMask`) exactly as the daemon DB stores them.
- Addresses are JSON numbers (uint64); UUIDs uppercase. No per-symbol kernel flag.

## How

Refactors `syms.Scan`'s traversal onto a shared internal visitor so the daemon DB path and the new streaming path reuse the **same** DSC / kernel / file-system walking and the **identical** symbol/address normalization. The DB path is rebuilt by an accumulator that reproduces the previous nested model graph; the streaming path emits JSONL as images are discovered (bufio + `encoding/json` per line, HTML-escaping off), so tens of millions of symbols are never buffered in memory.

## Verification

- `go build ./...` and `go vet ./internal/syms/` clean; `go test ./internal/syms/` passes (emitter line-types/fields, DB-accumulator graph equivalence, platform derivation).
- Ran against `iPhone18,1_26.5_23F77_Restore.ipsw`:
  - `--kernel`: 1 `ipsw` line, 1 `kernel` + 298 `kext` images, 198,247 symbols; every symbol `start`/`end` bit-63-cleared. The name `func_fffffe000a63c000` encodes raw `0xFFFFFE000A63C000`; emitted `start` = `0x7FFFFE000A63C000` (raw `& highestBitMask`) — byte-identical to the daemon.
  - `--dyld`: 2 `dsc` lines (`shared_region_start=0x180000000`), 4,362 dylibs, **13.78M** symbols streamed to disk with bounded memory; every dylib carries a `dsc_uuid` matching a `dsc` line.
  - Round-trip: `start <= addr < end` holds, so any symbol resolvable via `/v1/syms/{uuid}/{addr}` is derivable from the JSONL.