### PR TITLE
feat(extract): support RosettaOS x86_64 DSC

### DIFF
--- a/cmd/ipsw/cmd/extract.go
+++ b/cmd/ipsw/cmd/extract.go
@@ -75,6 +75,7 @@ func init() {
 			"fs\tFileSystem",
 			"exc\tExclave",
 			"rdisk\tRestoreRamDisk",
+			"rosetta\tRosettaOS",
 		}, cobra.ShellCompDirectiveDefault
 	})
 

--- a/internal/commands/extract/extract.go
+++ b/internal/commands/extract/extract.go
@@ -83,7 +83,7 @@ type Config struct {
 	// search the DMGs for files
 	DMGs bool `json:"dmgs,omitempty"`
 	// type of DMG to extract
-	// pattern: (app|sys|fs)
+	// pattern: (app|sys|fs|exc|rdisk|rosetta)
 	DmgType string `json:"dmg_type,omitempty"`
 	// flatten the extracted files paths (remove the folders)
 	Flatten bool `json:"flatten,omitempty"`
@@ -995,33 +995,122 @@ func DSC(c *Config) ([]string, error) {
 			}
 			return nil, fmt.Errorf("extracting dyld_shared_cache from remote OTA is only supported on macOS")
 		}
-		sysDMG, err := i.GetSystemOsDmg()
-		if err != nil {
-			return nil, fmt.Errorf("only iOS16.x/macOS13.x+ supported: failed to get SystemOS DMG from remote zip metadata: %v", err)
-		}
-		if len(sysDMG) == 0 {
-			return nil, fmt.Errorf("only iOS16.x/macOS13.x+ supported: no SystemOS DMG found in remote zip metadata")
-		}
-		zr, err = tuneRemoteZipReader(c, zr, matchingZipFileName(zr.File, sysDMG))
+		steps, err := remoteDscExtractionSteps(i, c.Arches)
 		if err != nil {
 			return nil, err
 		}
-		tmpDIR, err := os.MkdirTemp("", "ipsw_extract_remote_dyld")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create temporary directory to store SystemOS DMG: %v", err)
+		var out []string
+		for _, step := range steps {
+			stepOut, err := extractRemoteDscDMG(c, i, zr, step.dmgPath, folder, step.arches)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, stepOut...)
 		}
-		defer os.RemoveAll(tmpDIR)
-		sysDMGRegex := exactZipNamePattern(sysDMG)
-		extracted, err := utils.SearchZip(zr.File, sysDMGRegex, tmpDIR, c.Flatten, true)
-		if err != nil {
-			return nil, fmt.Errorf("failed to extract SystemOS DMG from remote IPSW: %v", err)
-		}
-		if len(extracted) == 0 {
-			return nil, fmt.Errorf("failed to extract SystemOS DMG %s from remote IPSW", sysDMG)
-		}
-		return dyld.ExtractFromDMG(i, extracted[0], filepath.Join(filepath.Clean(c.Output), folder), c.PemDB, c.Arches, c.DriverKit, c.AllDSCs)
+		return out, nil
 	}
 	return nil, fmt.Errorf("no IPSW or URL provided")
+}
+
+type remoteDscExtractionStep struct {
+	dmgPath string
+	arches  []string
+}
+
+func remoteDscExtractionSteps(i *info.Info, arches []string) ([]remoteDscExtractionStep, error) {
+	rosettaDMG, rosettaErr := i.GetRosettaOsDmg()
+	if len(arches) == 0 || !remoteX86DscRequiresRosetta(i) {
+		sysDMG, err := remoteSystemDscDMG(i)
+		if err != nil {
+			return nil, err
+		}
+		return []remoteDscExtractionStep{{dmgPath: sysDMG, arches: arches}}, nil
+	}
+
+	var systemArches []string
+	var rosettaArches []string
+	for _, arch := range arches {
+		if remoteDscArchUsesRosetta(arch) {
+			rosettaArches = append(rosettaArches, arch)
+		} else {
+			systemArches = append(systemArches, arch)
+		}
+	}
+
+	if len(rosettaArches) > 0 && rosettaErr != nil {
+		if remoteX86DscRequiresRosetta(i) {
+			return nil, fmt.Errorf("macOS 27+ x86_64 dyld_shared_cache requires Cryptex1,RosettaOS in BuildManifest")
+		}
+		sysDMG, err := remoteSystemDscDMG(i)
+		if err != nil {
+			return nil, err
+		}
+		return []remoteDscExtractionStep{{dmgPath: sysDMG, arches: arches}}, nil
+	}
+
+	steps := make([]remoteDscExtractionStep, 0, 2)
+	if len(systemArches) > 0 {
+		sysDMG, err := remoteSystemDscDMG(i)
+		if err != nil {
+			return nil, err
+		}
+		steps = append(steps, remoteDscExtractionStep{dmgPath: sysDMG, arches: systemArches})
+	}
+	if len(rosettaArches) > 0 {
+		steps = append(steps, remoteDscExtractionStep{dmgPath: rosettaDMG, arches: rosettaArches})
+	}
+	return steps, nil
+}
+
+func remoteDscArchUsesRosetta(arch string) bool {
+	switch arch {
+	case "x86_64", "x86_64h", "aot":
+		return true
+	default:
+		return false
+	}
+}
+
+func remoteX86DscRequiresRosetta(i *info.Info) bool {
+	if i == nil || i.Plists == nil || i.Plists.BuildManifest == nil {
+		return false
+	}
+	if !utils.StrSliceContains(i.Plists.BuildManifest.SupportedProductTypes, "mac") {
+		return false
+	}
+	return utils.Compare(i.Plists.BuildManifest.ProductVersion, "27.0") >= 0
+}
+
+func remoteSystemDscDMG(i *info.Info) (string, error) {
+	sysDMG, err := i.GetSystemOsDmg()
+	if err != nil {
+		return "", fmt.Errorf("only iOS16.x/macOS13.x+ supported: failed to get SystemOS DMG from remote zip metadata: %v", err)
+	}
+	if len(sysDMG) == 0 {
+		return "", fmt.Errorf("only iOS16.x/macOS13.x+ supported: no SystemOS DMG found in remote zip metadata")
+	}
+	return sysDMG, nil
+}
+
+func extractRemoteDscDMG(c *Config, i *info.Info, zr *zip.Reader, dmgPath, folder string, arches []string) ([]string, error) {
+	stepZr, err := tuneRemoteZipReader(c, zr, matchingZipFileName(zr.File, dmgPath))
+	if err != nil {
+		return nil, err
+	}
+	tmpDIR, err := os.MkdirTemp("", "ipsw_extract_remote_dyld")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary directory to store %s: %v", dmgPath, err)
+	}
+	defer os.RemoveAll(tmpDIR)
+	dmgRegex := exactZipNamePattern(dmgPath)
+	extracted, err := utils.SearchZip(stepZr.File, dmgRegex, tmpDIR, c.Flatten, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract %s from remote IPSW: %v", dmgPath, err)
+	}
+	if len(extracted) == 0 {
+		return nil, fmt.Errorf("failed to extract DMG %s from remote IPSW", dmgPath)
+	}
+	return dyld.ExtractFromDMG(i, extracted[0], filepath.Join(filepath.Clean(c.Output), folder), c.PemDB, arches, c.DriverKit, c.AllDSCs)
 }
 
 // DMG extracts the DMG from an IPSW

--- a/internal/commands/extract/extract_test.go
+++ b/internal/commands/extract/extract_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -317,6 +318,81 @@ func makeUnencryptedKernelPayload(t *testing.T, plaintext []byte) []byte {
 		t.Fatalf("Marshal() error = %v", err)
 	}
 	return data
+}
+
+func TestRemoteDscExtractionStepsRouteRosettaArches(t *testing.T) {
+	i := testDscInfo(true, "27.0")
+	got, err := remoteDscExtractionSteps(i, []string{"arm64e", "x86_64"})
+	if err != nil {
+		t.Fatalf("remoteDscExtractionSteps() error = %v", err)
+	}
+	want := []remoteDscExtractionStep{
+		{dmgPath: "system.dmg.aea", arches: []string{"arm64e"}},
+		{dmgPath: "rosetta.dmg", arches: []string{"x86_64"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("remoteDscExtractionSteps() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRemoteDscExtractionStepsKeepX86InSystemWhenRosettaMissing(t *testing.T) {
+	i := testDscInfo(false)
+	got, err := remoteDscExtractionSteps(i, []string{"x86_64"})
+	if err != nil {
+		t.Fatalf("remoteDscExtractionSteps() error = %v", err)
+	}
+	want := []remoteDscExtractionStep{{dmgPath: "system.dmg.aea", arches: []string{"x86_64"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("remoteDscExtractionSteps() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRemoteDscExtractionStepsIgnoreRosettaBeforeMacOS27(t *testing.T) {
+	i := testDscInfo(true, "26.5")
+	got, err := remoteDscExtractionSteps(i, []string{"x86_64"})
+	if err != nil {
+		t.Fatalf("remoteDscExtractionSteps() error = %v", err)
+	}
+	want := []remoteDscExtractionStep{{dmgPath: "system.dmg.aea", arches: []string{"x86_64"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("remoteDscExtractionSteps() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRemoteDscExtractionStepsRequireRosettaForMacOS27(t *testing.T) {
+	i := testDscInfo(false, "27.0")
+	_, err := remoteDscExtractionSteps(i, []string{"x86_64"})
+	if err == nil {
+		t.Fatal("remoteDscExtractionSteps() error = nil, want error")
+	}
+}
+
+func testDscInfo(hasRosetta bool, version ...string) *info.Info {
+	manifest := map[string]plist.IdentityManifest{
+		"Cryptex1,SystemOS": {
+			Info: map[string]any{"Path": "system.dmg.aea"},
+		},
+	}
+	if hasRosetta {
+		manifest["Cryptex1,RosettaOS"] = plist.IdentityManifest{
+			Info: map[string]any{"Path": "rosetta.dmg"},
+		}
+	}
+	productVersion := "26.0"
+	if len(version) > 0 {
+		productVersion = version[0]
+	}
+	return &info.Info{
+		Plists: &plist.Plists{
+			BuildManifest: &plist.BuildManifest{
+				ProductVersion:        productVersion,
+				SupportedProductTypes: []string{"Mac17,1"},
+				BuildIdentities: []plist.BuildIdentity{
+					{Manifest: manifest},
+				},
+			},
+		},
+	}
 }
 
 func testKernelInfo(kernelPaths ...string) *info.Info {

--- a/pkg/dyld/extract.go
+++ b/pkg/dyld/extract.go
@@ -30,6 +30,18 @@ var DscArches = []string{
 	"arm64", "arm64e", "x86_64", "x86_64h", "aot",
 }
 
+type dscDMGKind string
+
+const (
+	systemOSDscDMG  dscDMGKind = "SystemOS"
+	rosettaOSDscDMG dscDMGKind = "RosettaOS"
+)
+
+type dscExtractionStep struct {
+	kind   dscDMGKind
+	arches []string
+}
+
 func GetDscPathsInMount(mountPoint string, driverKit, all bool) ([]string, error) {
 	var matches []string
 	var re *regexp.Regexp
@@ -61,6 +73,80 @@ func GetDscPathsInMount(mountPoint string, driverKit, all bool) ([]string, error
 	}
 
 	return matches, nil
+}
+
+func dscExtractionPlan(arches []string, hasRosettaOS, requiresRosetta bool) ([]dscExtractionStep, error) {
+	if len(arches) == 0 || !requiresRosetta {
+		return []dscExtractionStep{{kind: systemOSDscDMG, arches: arches}}, nil
+	}
+
+	var systemArches []string
+	var rosettaArches []string
+	for _, arch := range arches {
+		if isRosettaDscArch(arch) {
+			rosettaArches = append(rosettaArches, arch)
+		} else {
+			systemArches = append(systemArches, arch)
+		}
+	}
+
+	if len(rosettaArches) > 0 && !hasRosettaOS {
+		if requiresRosetta {
+			return nil, fmt.Errorf("macOS 27+ x86_64 dyld_shared_cache requires Cryptex1,RosettaOS in BuildManifest")
+		}
+		return []dscExtractionStep{{kind: systemOSDscDMG, arches: arches}}, nil
+	}
+
+	steps := make([]dscExtractionStep, 0, 2)
+	if len(systemArches) > 0 {
+		steps = append(steps, dscExtractionStep{kind: systemOSDscDMG, arches: systemArches})
+	}
+	if len(rosettaArches) > 0 {
+		steps = append(steps, dscExtractionStep{kind: rosettaOSDscDMG, arches: rosettaArches})
+	}
+	return steps, nil
+}
+
+func macOSX86DscRequiresRosetta(i *info.Info) bool {
+	if i == nil || i.Plists == nil || i.Plists.BuildManifest == nil {
+		return false
+	}
+	if !utils.StrSliceContains(i.Plists.BuildManifest.SupportedProductTypes, "mac") {
+		return false
+	}
+	return utils.Compare(i.Plists.BuildManifest.ProductVersion, "27.0") >= 0
+}
+
+func isRosettaDscArch(arch string) bool {
+	switch arch {
+	case "x86_64", "x86_64h", "aot":
+		return true
+	default:
+		return false
+	}
+}
+
+func dscArchRegexParts(arches []string) []string {
+	parts := make([]string, 0, len(arches))
+	for _, arch := range arches {
+		switch arch {
+		case "aot":
+			parts = append(parts, "x86_64h?")
+		default:
+			parts = append(parts, regexp.QuoteMeta(arch))
+		}
+	}
+	return parts
+}
+
+func dscPathRegex(driverkit, all bool) string {
+	if driverkit {
+		return DriverKitCacheRegex
+	}
+	if all {
+		return CacheUberRegex
+	}
+	return CacheRegex
 }
 
 func ExtractFromDMG(i *info.Info, dmgPath, destPath, pemDB string, arches []string, driverkit, all bool) ([]string, error) {
@@ -129,6 +215,7 @@ func ExtractFromDMG(i *info.Info, dmgPath, destPath, pemDB string, arches []stri
 		}
 	}
 
+	mountedRoot := utils.MountedFilesystemRoot(mountPoint)
 	matches, err := GetDscPathsInMount(mountPoint, driverkit, all)
 	if err != nil {
 		return nil, err
@@ -152,7 +239,8 @@ func ExtractFromDMG(i *info.Info, dmgPath, destPath, pemDB string, arches []stri
 			matches = selMatches
 		} else {
 			var filtered []string
-			r := regexp.MustCompile(fmt.Sprintf("%s(%s)%s", CacheRegex, strings.Join(arches, "|"), CacheRegexEnding))
+			archPatterns := dscArchRegexParts(arches)
+			r := regexp.MustCompile(fmt.Sprintf("%s(%s)%s", dscPathRegex(driverkit, all), strings.Join(archPatterns, "|"), CacheRegexEnding))
 			for _, match := range matches {
 				if r.MatchString(match) {
 					filtered = append(filtered, match)
@@ -173,6 +261,11 @@ func ExtractFromDMG(i *info.Info, dmgPath, destPath, pemDB string, arches []stri
 	var artifacts []string
 	for _, match := range matches {
 		dyldDest := filepath.Join(destPath, filepath.Base(match))
+		if all {
+			if rel, err := filepath.Rel(mountedRoot, match); err == nil && !strings.HasPrefix(rel, "..") {
+				dyldDest = filepath.Join(destPath, rel)
+			}
+		}
 		// TODO: remove this (was commented out because I added --json to `ipsw extract` so the higher level func is now where this is printed)
 		// utils.Indent(log.Info, 3)(fmt.Sprintf("Extracting %s to %s", filepath.Base(match), dyldDest))
 		if err := utils.Copy(match, dyldDest); err != nil {
@@ -196,36 +289,80 @@ func Extract(ipsw, destPath, pemDB string, arches []string, driverkit, all bool)
 		return nil, fmt.Errorf("failed to parse IPSW: %v", err)
 	}
 
-	dmgPath, err := i.GetSystemOsDmg()
+	_, rosettaErr := i.GetRosettaOsDmg()
+	steps, err := dscExtractionPlan(arches, rosettaErr == nil, macOSX86DscRequiresRosetta(i))
 	if err != nil {
-		dmgPath, err = i.GetFileSystemOsDmg()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get DMG containing the dyld_shared_caches: %v", err)
-		}
+		return nil, err
 	}
 
-	// check if filesystem DMG already exists (due to previous mount command)
-	if _, err := os.Stat(dmgPath); os.IsNotExist(err) {
-		tmpDIR, err := os.MkdirTemp("", "ipsw_extract_dyld")
+	var artifacts []string
+	for _, step := range steps {
+		dmgPath, err := dmgPathForDscStep(i, step.kind)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create temporary directory: %v", err)
+			return nil, err
 		}
-		defer os.RemoveAll(tmpDIR)
 
-		dmgs, err := utils.Unzip(ipsw, tmpDIR, func(f *zip.File) bool {
-			return strings.EqualFold(filepath.Base(f.Name), dmgPath)
-		})
+		localDMGPath, cleanup, err := extractDmgFromIPSWIfNeeded(ipsw, dmgPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to extract %s from IPSW: %v", dmgPath, err)
+			return nil, err
 		}
-		if len(dmgs) == 0 {
-			return nil, fmt.Errorf("File System %s NOT found in IPSW", dmgPath)
+
+		stepArtifacts, err := ExtractFromDMG(i, localDMGPath, destPath, pemDB, step.arches, driverkit, all)
+		cleanup()
+		if err != nil {
+			return nil, err
 		}
-		// Update dmgPath to point to the extracted file location
-		dmgPath = dmgs[0]
+		artifacts = append(artifacts, stepArtifacts...)
 	}
 
-	return ExtractFromDMG(i, dmgPath, destPath, pemDB, arches, driverkit, all)
+	return artifacts, nil
+}
+
+func dmgPathForDscStep(i *info.Info, kind dscDMGKind) (string, error) {
+	switch kind {
+	case rosettaOSDscDMG:
+		dmgPath, err := i.GetRosettaOsDmg()
+		if err != nil {
+			return "", fmt.Errorf("failed to get RosettaOS DMG containing the x86_64 dyld_shared_cache(s): %v", err)
+		}
+		return dmgPath, nil
+	default:
+		dmgPath, err := i.GetSystemOsDmg()
+		if err != nil {
+			dmgPath, err = i.GetFileSystemOsDmg()
+			if err != nil {
+				return "", fmt.Errorf("failed to get DMG containing the dyld_shared_caches: %v", err)
+			}
+		}
+		return dmgPath, nil
+	}
+}
+
+func extractDmgFromIPSWIfNeeded(ipsw, dmgPath string) (string, func(), error) {
+	// Check if filesystem DMG already exists (due to previous mount command).
+	if _, err := os.Stat(dmgPath); err == nil {
+		return dmgPath, func() {}, nil
+	}
+
+	tmpDIR, err := os.MkdirTemp("", "ipsw_extract_dyld")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temporary directory: %v", err)
+	}
+	cleanup := func() { os.RemoveAll(tmpDIR) }
+
+	dmgs, err := utils.Unzip(ipsw, tmpDIR, func(f *zip.File) bool {
+		return strings.EqualFold(f.Name, dmgPath) || strings.EqualFold(filepath.Base(f.Name), dmgPath)
+	})
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to extract %s from IPSW: %v", dmgPath, err)
+	}
+	if len(dmgs) == 0 {
+		cleanup()
+		return "", nil, fmt.Errorf("DMG %s NOT found in IPSW", dmgPath)
+	}
+
+	return dmgs[0], cleanup, nil
 }
 
 // RemoteCryptexPattern returns the ZIP member matcher used for remote OTA

--- a/pkg/dyld/extract_test.go
+++ b/pkg/dyld/extract_test.go
@@ -62,10 +62,104 @@ func TestRemoteCryptexFilesArchFiltering(t *testing.T) {
 	}
 }
 
+func TestDscExtractionPlanRoutesRosettaArches(t *testing.T) {
+	tests := []struct {
+		name            string
+		arches          []string
+		hasRosettaOS    bool
+		requiresRosetta bool
+		want            []dscExtractionStep
+		wantErr         bool
+	}{
+		{
+			name:            "legacy x86 stays in system os when rosetta os is absent",
+			arches:          []string{"x86_64"},
+			hasRosettaOS:    false,
+			requiresRosetta: false,
+			want:            []dscExtractionStep{{kind: systemOSDscDMG, arches: []string{"x86_64"}}},
+		},
+		{
+			name:            "empty arches preserve existing system os behavior",
+			arches:          nil,
+			hasRosettaOS:    true,
+			requiresRosetta: true,
+			want:            []dscExtractionStep{{kind: systemOSDscDMG, arches: nil}},
+		},
+		{
+			name:            "rosetta os before it is required keeps legacy system os extraction",
+			arches:          []string{"x86_64"},
+			hasRosettaOS:    true,
+			requiresRosetta: false,
+			want:            []dscExtractionStep{{kind: systemOSDscDMG, arches: []string{"x86_64"}}},
+		},
+		{
+			name:            "x86_64 uses rosetta os when available",
+			arches:          []string{"x86_64"},
+			hasRosettaOS:    true,
+			requiresRosetta: true,
+			want:            []dscExtractionStep{{kind: rosettaOSDscDMG, arches: []string{"x86_64"}}},
+		},
+		{
+			name:            "mixed arches split system and rosetta os",
+			arches:          []string{"arm64e", "x86_64"},
+			hasRosettaOS:    true,
+			requiresRosetta: true,
+			want: []dscExtractionStep{
+				{kind: systemOSDscDMG, arches: []string{"arm64e"}},
+				{kind: rosettaOSDscDMG, arches: []string{"x86_64"}},
+			},
+		},
+		{
+			name:            "aot follows the rosetta os x86 cache family",
+			arches:          []string{"aot"},
+			hasRosettaOS:    true,
+			requiresRosetta: true,
+			want:            []dscExtractionStep{{kind: rosettaOSDscDMG, arches: []string{"aot"}}},
+		},
+		{
+			name:            "required rosetta os fails instead of falling back to system os",
+			arches:          []string{"x86_64"},
+			hasRosettaOS:    false,
+			requiresRosetta: true,
+			wantErr:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := dscExtractionPlan(test.arches, test.hasRosettaOS, test.requiresRosetta)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("dscExtractionPlan(%v, %v, %v) error = nil, want error", test.arches, test.hasRosettaOS, test.requiresRosetta)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("dscExtractionPlan(%v, %v, %v) error = %v", test.arches, test.hasRosettaOS, test.requiresRosetta, err)
+			}
+			if !equalDscExtractionSteps(got, test.want) {
+				t.Fatalf("dscExtractionPlan(%v, %v, %v) = %#v, want %#v", test.arches, test.hasRosettaOS, test.requiresRosetta, got, test.want)
+			}
+		})
+	}
+}
+
 func zipFileNames(files []*zip.File) []string {
 	names := make([]string, 0, len(files))
 	for _, file := range files {
 		names = append(names, file.Name)
 	}
 	return names
+}
+
+func equalDscExtractionSteps(a, b []dscExtractionStep) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for idx := range a {
+		if a[idx].kind != b[idx].kind || !slices.Equal(a[idx].arches, b[idx].arches) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/dyld/types.go
+++ b/pkg/dyld/types.go
@@ -16,12 +16,14 @@ const (
 	MacOSCacheFolder      = "System/Library/dyld/"
 	IPhoneCacheFolder     = "System/Library/Caches/com.apple.dyld/"
 	DriverKitCacheFolder  = "System/DriverKit/System/Library/dyld/"
+	X86SupportCacheFolder = "System/x86Support/System/Library/dyld/"
 	ExclavekitCacheFolder = "/System/ExclaveKit/System/Library/dyld/"
 
 	CacheRegex                             = `System/Library/(dyld|Caches/com\.apple\.dyld)/dyld_shared_cache_`
 	DriverKitCacheRegex                    = `System/DriverKit/System/Library/dyld/dyld_shared_cache_`
+	X86SupportCacheRegex                   = `System/x86Support/System/Library/dyld/dyld_shared_cache_`
 	CacheRegexEnding                       = `(\..*)?$`
-	CacheUberRegex                         = `(System/DriverKit/)?System/Library/(dyld|Caches/com\.apple\.dyld)/dyld_shared_cache_`
+	CacheUberRegex                         = `(System/DriverKit/|System/x86Support/)?System/Library/(dyld|Caches/com\.apple\.dyld)/dyld_shared_cache_`
 	DYLD_SHARED_CACHE_DYNAMIC_MAGIC_PREFIX = "dyld_v1"
 	DYLD_SHARED_CACHE_DYNAMIC_DATA_MAGIC   = "dyld_data    v0"
 )


### PR DESCRIPTION
## Summary

The latest macOS 27 beta IPSW moves the `x86_64` DSC to the `RosettaOS` image. I co-developed this with implementation in symx: https://github.com/getsentry/symx/pull/83

I saw that you added support for `RosettaOS` mounting, so maybe you already have something similar in the pipeline, but I thought I might cross-check with you anyway.

Since there is no `RosettaOS` AEA image packaged in the beta IPSW, I consider this not supported at this point because I can't test it yet.

## Testing

ran locally:
```
ipsw extract UniversalMac_27.0_26A5353q_Restore.ipsw -d -a x86_64
```

Also ran the added unit-tests or tests of touched modules:
```
go test ./pkg/dyld ./internal/commands/extract ./cmd/ipsw/cmd
```

Let `symx` [rerun](https://github.com/getsentry/symx/actions/runs/27369178528/job/80876581478) against recent 26.5, 26.5.1, 26.6 beta, and 27.0 beta releases which also showed that, with these changes, we uploaded an additional 11751 files to the symbol store for the macOS 27 release (not all binaries in our case).

## AI Assistance

Used codex to understand the new structure in the IPSW. Cursor gave me very useful feedback on my symx PR.