### PR TITLE
refactor(dyld): unify DSC plan, extract RosettaOS by default

### DIFF
--- a/internal/commands/extract/extract.go
+++ b/internal/commands/extract/extract.go
@@ -1009,6 +1009,11 @@ func DSC(c *Config) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
+			if stepOut == nil {
+				// nil output with no error means the user interrupted the
+				// interactive cache selection; don't prompt for remaining DMGs
+				return out, nil
+			}
 			out = append(out, stepOut...)
 		}
 		return out, nil
@@ -1017,14 +1022,18 @@ func DSC(c *Config) ([]string, error) {
 }
 
 func remoteDmgPathForDscStep(i *info.Info, kind dyld.DscDMGKind) (string, error) {
-	if kind == dyld.RosettaOSDscDMG {
+	switch kind {
+	case dyld.RosettaOSDscDMG:
 		dmgPath, err := i.GetRosettaOsDmg()
 		if err != nil {
 			return "", fmt.Errorf("failed to get RosettaOS DMG containing the x86_64 dyld_shared_cache(s) from remote zip metadata: %v", err)
 		}
 		return dmgPath, nil
+	case dyld.SystemOSDscDMG:
+		return remoteSystemDscDMG(i)
+	default:
+		return "", fmt.Errorf("unsupported dyld_shared_cache DMG kind: %s", kind)
 	}
-	return remoteSystemDscDMG(i)
 }
 
 func remoteSystemDscDMG(i *info.Info) (string, error) {

--- a/internal/commands/extract/extract.go
+++ b/internal/commands/extract/extract.go
@@ -995,13 +995,17 @@ func DSC(c *Config) ([]string, error) {
 			}
 			return nil, fmt.Errorf("extracting dyld_shared_cache from remote OTA is only supported on macOS")
 		}
-		steps, err := remoteDscExtractionSteps(i, c.Arches)
+		steps, err := dyld.DscExtractionPlan(i, c.Arches)
 		if err != nil {
 			return nil, err
 		}
 		var out []string
 		for _, step := range steps {
-			stepOut, err := extractRemoteDscDMG(c, i, zr, step.dmgPath, folder, step.arches)
+			dmgPath, err := remoteDmgPathForDscStep(i, step.Kind)
+			if err != nil {
+				return nil, err
+			}
+			stepOut, err := extractRemoteDscDMG(c, i, zr, dmgPath, folder, step.Arches)
 			if err != nil {
 				return nil, err
 			}
@@ -1012,73 +1016,15 @@ func DSC(c *Config) ([]string, error) {
 	return nil, fmt.Errorf("no IPSW or URL provided")
 }
 
-type remoteDscExtractionStep struct {
-	dmgPath string
-	arches  []string
-}
-
-func remoteDscExtractionSteps(i *info.Info, arches []string) ([]remoteDscExtractionStep, error) {
-	rosettaDMG, rosettaErr := i.GetRosettaOsDmg()
-	if len(arches) == 0 || !remoteX86DscRequiresRosetta(i) {
-		sysDMG, err := remoteSystemDscDMG(i)
+func remoteDmgPathForDscStep(i *info.Info, kind dyld.DscDMGKind) (string, error) {
+	if kind == dyld.RosettaOSDscDMG {
+		dmgPath, err := i.GetRosettaOsDmg()
 		if err != nil {
-			return nil, err
+			return "", fmt.Errorf("failed to get RosettaOS DMG containing the x86_64 dyld_shared_cache(s) from remote zip metadata: %v", err)
 		}
-		return []remoteDscExtractionStep{{dmgPath: sysDMG, arches: arches}}, nil
+		return dmgPath, nil
 	}
-
-	var systemArches []string
-	var rosettaArches []string
-	for _, arch := range arches {
-		if remoteDscArchUsesRosetta(arch) {
-			rosettaArches = append(rosettaArches, arch)
-		} else {
-			systemArches = append(systemArches, arch)
-		}
-	}
-
-	if len(rosettaArches) > 0 && rosettaErr != nil {
-		if remoteX86DscRequiresRosetta(i) {
-			return nil, fmt.Errorf("macOS 27+ x86_64 dyld_shared_cache requires Cryptex1,RosettaOS in BuildManifest")
-		}
-		sysDMG, err := remoteSystemDscDMG(i)
-		if err != nil {
-			return nil, err
-		}
-		return []remoteDscExtractionStep{{dmgPath: sysDMG, arches: arches}}, nil
-	}
-
-	steps := make([]remoteDscExtractionStep, 0, 2)
-	if len(systemArches) > 0 {
-		sysDMG, err := remoteSystemDscDMG(i)
-		if err != nil {
-			return nil, err
-		}
-		steps = append(steps, remoteDscExtractionStep{dmgPath: sysDMG, arches: systemArches})
-	}
-	if len(rosettaArches) > 0 {
-		steps = append(steps, remoteDscExtractionStep{dmgPath: rosettaDMG, arches: rosettaArches})
-	}
-	return steps, nil
-}
-
-func remoteDscArchUsesRosetta(arch string) bool {
-	switch arch {
-	case "x86_64", "x86_64h", "aot":
-		return true
-	default:
-		return false
-	}
-}
-
-func remoteX86DscRequiresRosetta(i *info.Info) bool {
-	if i == nil || i.Plists == nil || i.Plists.BuildManifest == nil {
-		return false
-	}
-	if !utils.StrSliceContains(i.Plists.BuildManifest.SupportedProductTypes, "mac") {
-		return false
-	}
-	return utils.Compare(i.Plists.BuildManifest.ProductVersion, "27.0") >= 0
+	return remoteSystemDscDMG(i)
 }
 
 func remoteSystemDscDMG(i *info.Info) (string, error) {

--- a/internal/commands/extract/extract_test.go
+++ b/internal/commands/extract/extract_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/blacktop/ipsw/internal/download"
+	"github.com/blacktop/ipsw/pkg/dyld"
 	"github.com/blacktop/ipsw/pkg/img4"
 	"github.com/blacktop/ipsw/pkg/info"
 	"github.com/blacktop/ipsw/pkg/plist"
@@ -320,50 +321,83 @@ func makeUnencryptedKernelPayload(t *testing.T, plaintext []byte) []byte {
 	return data
 }
 
-func TestRemoteDscExtractionStepsRouteRosettaArches(t *testing.T) {
-	i := testDscInfo(true, "27.0")
-	got, err := remoteDscExtractionSteps(i, []string{"arm64e", "x86_64"})
-	if err != nil {
-		t.Fatalf("remoteDscExtractionSteps() error = %v", err)
-	}
-	want := []remoteDscExtractionStep{
-		{dmgPath: "system.dmg.aea", arches: []string{"arm64e"}},
-		{dmgPath: "rosetta.dmg", arches: []string{"x86_64"}},
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("remoteDscExtractionSteps() = %#v, want %#v", got, want)
-	}
+// resolvedDscStep pairs a planned step's resolved remote DMG path with its
+// arches, mirroring what the remote DSC loop feeds extractRemoteDscDMG.
+type resolvedDscStep struct {
+	dmgPath string
+	arches  []string
 }
 
-func TestRemoteDscExtractionStepsKeepX86InSystemWhenRosettaMissing(t *testing.T) {
-	i := testDscInfo(false)
-	got, err := remoteDscExtractionSteps(i, []string{"x86_64"})
-	if err != nil {
-		t.Fatalf("remoteDscExtractionSteps() error = %v", err)
+func TestRemoteDscPlanRouting(t *testing.T) {
+	tests := []struct {
+		name    string
+		info    *info.Info
+		arches  []string
+		want    []resolvedDscStep
+		wantErr bool
+	}{
+		{
+			name:   "macOS 27 routes rosetta arches to rosetta dmg",
+			info:   testDscInfo(true, "27.0"),
+			arches: []string{"arm64e", "x86_64"},
+			want: []resolvedDscStep{
+				{dmgPath: "system.dmg.aea", arches: []string{"arm64e"}},
+				{dmgPath: "rosetta.dmg", arches: []string{"x86_64"}},
+			},
+		},
+		{
+			name:   "macOS 27 default arches cover both dmgs",
+			info:   testDscInfo(true, "27.0"),
+			arches: nil,
+			want: []resolvedDscStep{
+				{dmgPath: "system.dmg.aea"},
+				{dmgPath: "rosetta.dmg"},
+			},
+		},
+		{
+			name:   "x86 stays in system os when rosetta is missing pre-27",
+			info:   testDscInfo(false),
+			arches: []string{"x86_64"},
+			want:   []resolvedDscStep{{dmgPath: "system.dmg.aea", arches: []string{"x86_64"}}},
+		},
+		{
+			name:   "rosetta dmg is ignored before macOS 27",
+			info:   testDscInfo(true, "26.5"),
+			arches: []string{"x86_64"},
+			want:   []resolvedDscStep{{dmgPath: "system.dmg.aea", arches: []string{"x86_64"}}},
+		},
+		{
+			name:    "macOS 27 x86 without rosetta dmg fails",
+			info:    testDscInfo(false, "27.0"),
+			arches:  []string{"x86_64"},
+			wantErr: true,
+		},
 	}
-	want := []remoteDscExtractionStep{{dmgPath: "system.dmg.aea", arches: []string{"x86_64"}}}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("remoteDscExtractionSteps() = %#v, want %#v", got, want)
-	}
-}
 
-func TestRemoteDscExtractionStepsIgnoreRosettaBeforeMacOS27(t *testing.T) {
-	i := testDscInfo(true, "26.5")
-	got, err := remoteDscExtractionSteps(i, []string{"x86_64"})
-	if err != nil {
-		t.Fatalf("remoteDscExtractionSteps() error = %v", err)
-	}
-	want := []remoteDscExtractionStep{{dmgPath: "system.dmg.aea", arches: []string{"x86_64"}}}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("remoteDscExtractionSteps() = %#v, want %#v", got, want)
-	}
-}
-
-func TestRemoteDscExtractionStepsRequireRosettaForMacOS27(t *testing.T) {
-	i := testDscInfo(false, "27.0")
-	_, err := remoteDscExtractionSteps(i, []string{"x86_64"})
-	if err == nil {
-		t.Fatal("remoteDscExtractionSteps() error = nil, want error")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			steps, err := dyld.DscExtractionPlan(test.info, test.arches)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("DscExtractionPlan() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DscExtractionPlan() error = %v", err)
+			}
+			got := make([]resolvedDscStep, 0, len(steps))
+			for _, step := range steps {
+				dmgPath, err := remoteDmgPathForDscStep(test.info, step.Kind)
+				if err != nil {
+					t.Fatalf("remoteDmgPathForDscStep(%q) error = %v", step.Kind, err)
+				}
+				got = append(got, resolvedDscStep{dmgPath: dmgPath, arches: step.Arches})
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("resolved steps = %#v, want %#v", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/commands/extract/extract_test.go
+++ b/internal/commands/extract/extract_test.go
@@ -330,11 +330,12 @@ type resolvedDscStep struct {
 
 func TestRemoteDscPlanRouting(t *testing.T) {
 	tests := []struct {
-		name    string
-		info    *info.Info
-		arches  []string
-		want    []resolvedDscStep
-		wantErr bool
+		name        string
+		info        *info.Info
+		arches      []string
+		want        []resolvedDscStep
+		wantErr     bool
+		errContains string
 	}{
 		{
 			name:   "macOS 27 routes rosetta arches to rosetta dmg",
@@ -372,6 +373,13 @@ func TestRemoteDscPlanRouting(t *testing.T) {
 			arches:  []string{"x86_64"},
 			wantErr: true,
 		},
+		{
+			name:        "macOS 27 with conflicting rosetta dmgs fails instead of treating rosetta as absent",
+			info:        testDscInfoWithConflictingRosetta(),
+			arches:      []string{"x86_64"},
+			wantErr:     true,
+			errContains: "failed to determine RosettaOS DMG availability",
+		},
 	}
 
 	for _, test := range tests {
@@ -380,6 +388,9 @@ func TestRemoteDscPlanRouting(t *testing.T) {
 			if test.wantErr {
 				if err == nil {
 					t.Fatal("DscExtractionPlan() error = nil, want error")
+				}
+				if test.errContains != "" && !strings.Contains(err.Error(), test.errContains) {
+					t.Fatalf("DscExtractionPlan() error = %q, want it to contain %q", err, test.errContains)
 				}
 				return
 			}
@@ -427,6 +438,15 @@ func testDscInfo(hasRosetta bool, version ...string) *info.Info {
 			},
 		},
 	}
+}
+
+func testDscInfoWithConflictingRosetta() *info.Info {
+	i := testDscInfo(true, "27.0")
+	i.Plists.BuildManifest.BuildIdentities = append(i.Plists.BuildManifest.BuildIdentities,
+		plist.BuildIdentity{Manifest: map[string]plist.IdentityManifest{
+			"Cryptex1,RosettaOS": {Info: map[string]any{"Path": "rosetta-other.dmg"}},
+		}})
+	return i
 }
 
 func testKernelInfo(kernelPaths ...string) *info.Info {

--- a/pkg/dyld/extract.go
+++ b/pkg/dyld/extract.go
@@ -30,16 +30,20 @@ var DscArches = []string{
 	"arm64", "arm64e", "x86_64", "x86_64h", "aot",
 }
 
-type dscDMGKind string
+// DscDMGKind identifies which IPSW DMG a dyld_shared_cache extraction step
+// reads from.
+type DscDMGKind string
 
 const (
-	systemOSDscDMG  dscDMGKind = "SystemOS"
-	rosettaOSDscDMG dscDMGKind = "RosettaOS"
+	SystemOSDscDMG  DscDMGKind = "SystemOS"
+	RosettaOSDscDMG DscDMGKind = "RosettaOS"
 )
 
-type dscExtractionStep struct {
-	kind   dscDMGKind
-	arches []string
+// DscExtractionStep is one DMG to extract dyld_shared_cache(s) from, with the
+// arches to pull out of it (nil means all).
+type DscExtractionStep struct {
+	Kind   DscDMGKind
+	Arches []string
 }
 
 func GetDscPathsInMount(mountPoint string, driverKit, all bool) ([]string, error) {
@@ -75,9 +79,35 @@ func GetDscPathsInMount(mountPoint string, driverKit, all bool) ([]string, error
 	return matches, nil
 }
 
-func dscExtractionPlan(arches []string, hasRosettaOS, requiresRosetta bool) ([]dscExtractionStep, error) {
-	if len(arches) == 0 || !requiresRosetta {
-		return []dscExtractionStep{{kind: systemOSDscDMG, arches: arches}}, nil
+// DscExtractionPlan returns the DMG extraction steps needed to cover the
+// requested arches for the given IPSW. macOS 27+ moves the x86_64 family of
+// dyld_shared_caches into the Cryptex1,RosettaOS DMG, so plans for those
+// IPSWs can span two DMGs.
+func DscExtractionPlan(i *info.Info, arches []string) ([]DscExtractionStep, error) {
+	hasRosettaOS := false
+	if i != nil {
+		if _, err := i.GetRosettaOsDmg(); err == nil {
+			hasRosettaOS = true
+		}
+	}
+	requiresRosetta := macOSX86DscRequiresRosetta(i)
+	if requiresRosetta && !hasRosettaOS && len(arches) == 0 {
+		log.Warn("macOS 27+ moves x86_64 dyld_shared_cache(s) to the RosettaOS cryptex, but BuildManifest has no Cryptex1,RosettaOS; extracting SystemOS caches only")
+	}
+	return dscExtractionPlan(arches, hasRosettaOS, requiresRosetta)
+}
+
+func dscExtractionPlan(arches []string, hasRosettaOS, requiresRosetta bool) ([]DscExtractionStep, error) {
+	if !requiresRosetta {
+		return []DscExtractionStep{{Kind: SystemOSDscDMG, Arches: arches}}, nil
+	}
+
+	if len(arches) == 0 { // all arches: cover every DMG that carries DSCs
+		steps := []DscExtractionStep{{Kind: SystemOSDscDMG}}
+		if hasRosettaOS {
+			steps = append(steps, DscExtractionStep{Kind: RosettaOSDscDMG})
+		}
+		return steps, nil
 	}
 
 	var systemArches []string
@@ -91,18 +121,15 @@ func dscExtractionPlan(arches []string, hasRosettaOS, requiresRosetta bool) ([]d
 	}
 
 	if len(rosettaArches) > 0 && !hasRosettaOS {
-		if requiresRosetta {
-			return nil, fmt.Errorf("macOS 27+ x86_64 dyld_shared_cache requires Cryptex1,RosettaOS in BuildManifest")
-		}
-		return []dscExtractionStep{{kind: systemOSDscDMG, arches: arches}}, nil
+		return nil, fmt.Errorf("macOS 27+ x86_64 dyld_shared_cache requires Cryptex1,RosettaOS in BuildManifest")
 	}
 
-	steps := make([]dscExtractionStep, 0, 2)
+	steps := make([]DscExtractionStep, 0, 2)
 	if len(systemArches) > 0 {
-		steps = append(steps, dscExtractionStep{kind: systemOSDscDMG, arches: systemArches})
+		steps = append(steps, DscExtractionStep{Kind: SystemOSDscDMG, Arches: systemArches})
 	}
 	if len(rosettaArches) > 0 {
-		steps = append(steps, dscExtractionStep{kind: rosettaOSDscDMG, arches: rosettaArches})
+		steps = append(steps, DscExtractionStep{Kind: RosettaOSDscDMG, Arches: rosettaArches})
 	}
 	return steps, nil
 }
@@ -289,15 +316,14 @@ func Extract(ipsw, destPath, pemDB string, arches []string, driverkit, all bool)
 		return nil, fmt.Errorf("failed to parse IPSW: %v", err)
 	}
 
-	_, rosettaErr := i.GetRosettaOsDmg()
-	steps, err := dscExtractionPlan(arches, rosettaErr == nil, macOSX86DscRequiresRosetta(i))
+	steps, err := DscExtractionPlan(i, arches)
 	if err != nil {
 		return nil, err
 	}
 
 	var artifacts []string
 	for _, step := range steps {
-		dmgPath, err := dmgPathForDscStep(i, step.kind)
+		dmgPath, err := dmgPathForDscStep(i, step.Kind)
 		if err != nil {
 			return nil, err
 		}
@@ -307,7 +333,7 @@ func Extract(ipsw, destPath, pemDB string, arches []string, driverkit, all bool)
 			return nil, err
 		}
 
-		stepArtifacts, err := ExtractFromDMG(i, localDMGPath, destPath, pemDB, step.arches, driverkit, all)
+		stepArtifacts, err := ExtractFromDMG(i, localDMGPath, destPath, pemDB, step.Arches, driverkit, all)
 		cleanup()
 		if err != nil {
 			return nil, err
@@ -318,9 +344,9 @@ func Extract(ipsw, destPath, pemDB string, arches []string, driverkit, all bool)
 	return artifacts, nil
 }
 
-func dmgPathForDscStep(i *info.Info, kind dscDMGKind) (string, error) {
+func dmgPathForDscStep(i *info.Info, kind DscDMGKind) (string, error) {
 	switch kind {
-	case rosettaOSDscDMG:
+	case RosettaOSDscDMG:
 		dmgPath, err := i.GetRosettaOsDmg()
 		if err != nil {
 			return "", fmt.Errorf("failed to get RosettaOS DMG containing the x86_64 dyld_shared_cache(s): %v", err)

--- a/pkg/dyld/extract.go
+++ b/pkg/dyld/extract.go
@@ -84,17 +84,21 @@ func GetDscPathsInMount(mountPoint string, driverKit, all bool) ([]string, error
 // dyld_shared_caches into the Cryptex1,RosettaOS DMG, so plans for those
 // IPSWs can span two DMGs.
 func DscExtractionPlan(i *info.Info, arches []string) ([]DscExtractionStep, error) {
-	hasRosettaOS := false
-	if i != nil {
-		if _, err := i.GetRosettaOsDmg(); err == nil {
-			hasRosettaOS = true
-		}
+	if !macOSX86DscRequiresRosetta(i) {
+		return dscExtractionPlan(arches, false, false)
 	}
-	requiresRosetta := macOSX86DscRequiresRosetta(i)
-	if requiresRosetta && !hasRosettaOS && len(arches) == 0 {
+	hasRosettaOS := false
+	if _, err := i.GetRosettaOsDmg(); err == nil {
+		hasRosettaOS = true
+	} else if !errors.Is(err, info.ErrorCryptexNotFound) {
+		// a truly absent cryptex is handled below; anything else (e.g.
+		// multiple RosettaOS DMGs) would otherwise masquerade as "absent"
+		return nil, fmt.Errorf("failed to determine RosettaOS DMG availability: %w", err)
+	}
+	if !hasRosettaOS && len(arches) == 0 {
 		log.Warn("macOS 27+ moves x86_64 dyld_shared_cache(s) to the RosettaOS cryptex, but BuildManifest has no Cryptex1,RosettaOS; extracting SystemOS caches only")
 	}
-	return dscExtractionPlan(arches, hasRosettaOS, requiresRosetta)
+	return dscExtractionPlan(arches, hasRosettaOS, true)
 }
 
 func dscExtractionPlan(arches []string, hasRosettaOS, requiresRosetta bool) ([]DscExtractionStep, error) {
@@ -338,6 +342,11 @@ func Extract(ipsw, destPath, pemDB string, arches []string, driverkit, all bool)
 		if err != nil {
 			return nil, err
 		}
+		if stepArtifacts == nil {
+			// nil artifacts with no error means the user interrupted the
+			// interactive cache selection; don't prompt for remaining DMGs
+			return artifacts, nil
+		}
 		artifacts = append(artifacts, stepArtifacts...)
 	}
 
@@ -352,7 +361,7 @@ func dmgPathForDscStep(i *info.Info, kind DscDMGKind) (string, error) {
 			return "", fmt.Errorf("failed to get RosettaOS DMG containing the x86_64 dyld_shared_cache(s): %v", err)
 		}
 		return dmgPath, nil
-	default:
+	case SystemOSDscDMG:
 		dmgPath, err := i.GetSystemOsDmg()
 		if err != nil {
 			dmgPath, err = i.GetFileSystemOsDmg()
@@ -361,6 +370,8 @@ func dmgPathForDscStep(i *info.Info, kind DscDMGKind) (string, error) {
 			}
 		}
 		return dmgPath, nil
+	default:
+		return "", fmt.Errorf("unsupported dyld_shared_cache DMG kind: %s", kind)
 	}
 }
 

--- a/pkg/dyld/extract_test.go
+++ b/pkg/dyld/extract_test.go
@@ -68,7 +68,7 @@ func TestDscExtractionPlanRoutesRosettaArches(t *testing.T) {
 		arches          []string
 		hasRosettaOS    bool
 		requiresRosetta bool
-		want            []dscExtractionStep
+		want            []DscExtractionStep
 		wantErr         bool
 	}{
 		{
@@ -76,37 +76,47 @@ func TestDscExtractionPlanRoutesRosettaArches(t *testing.T) {
 			arches:          []string{"x86_64"},
 			hasRosettaOS:    false,
 			requiresRosetta: false,
-			want:            []dscExtractionStep{{kind: systemOSDscDMG, arches: []string{"x86_64"}}},
+			want:            []DscExtractionStep{{Kind: SystemOSDscDMG, Arches: []string{"x86_64"}}},
 		},
 		{
-			name:            "empty arches preserve existing system os behavior",
+			name:            "empty arches cover both system and rosetta os",
 			arches:          nil,
 			hasRosettaOS:    true,
 			requiresRosetta: true,
-			want:            []dscExtractionStep{{kind: systemOSDscDMG, arches: nil}},
+			want: []DscExtractionStep{
+				{Kind: SystemOSDscDMG},
+				{Kind: RosettaOSDscDMG},
+			},
+		},
+		{
+			name:            "empty arches fall back to system os when rosetta os is absent",
+			arches:          nil,
+			hasRosettaOS:    false,
+			requiresRosetta: true,
+			want:            []DscExtractionStep{{Kind: SystemOSDscDMG}},
 		},
 		{
 			name:            "rosetta os before it is required keeps legacy system os extraction",
 			arches:          []string{"x86_64"},
 			hasRosettaOS:    true,
 			requiresRosetta: false,
-			want:            []dscExtractionStep{{kind: systemOSDscDMG, arches: []string{"x86_64"}}},
+			want:            []DscExtractionStep{{Kind: SystemOSDscDMG, Arches: []string{"x86_64"}}},
 		},
 		{
 			name:            "x86_64 uses rosetta os when available",
 			arches:          []string{"x86_64"},
 			hasRosettaOS:    true,
 			requiresRosetta: true,
-			want:            []dscExtractionStep{{kind: rosettaOSDscDMG, arches: []string{"x86_64"}}},
+			want:            []DscExtractionStep{{Kind: RosettaOSDscDMG, Arches: []string{"x86_64"}}},
 		},
 		{
 			name:            "mixed arches split system and rosetta os",
 			arches:          []string{"arm64e", "x86_64"},
 			hasRosettaOS:    true,
 			requiresRosetta: true,
-			want: []dscExtractionStep{
-				{kind: systemOSDscDMG, arches: []string{"arm64e"}},
-				{kind: rosettaOSDscDMG, arches: []string{"x86_64"}},
+			want: []DscExtractionStep{
+				{Kind: SystemOSDscDMG, Arches: []string{"arm64e"}},
+				{Kind: RosettaOSDscDMG, Arches: []string{"x86_64"}},
 			},
 		},
 		{
@@ -114,7 +124,7 @@ func TestDscExtractionPlanRoutesRosettaArches(t *testing.T) {
 			arches:          []string{"aot"},
 			hasRosettaOS:    true,
 			requiresRosetta: true,
-			want:            []dscExtractionStep{{kind: rosettaOSDscDMG, arches: []string{"aot"}}},
+			want:            []DscExtractionStep{{Kind: RosettaOSDscDMG, Arches: []string{"aot"}}},
 		},
 		{
 			name:            "required rosetta os fails instead of falling back to system os",
@@ -152,12 +162,12 @@ func zipFileNames(files []*zip.File) []string {
 	return names
 }
 
-func equalDscExtractionSteps(a, b []dscExtractionStep) bool {
+func equalDscExtractionSteps(a, b []DscExtractionStep) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for idx := range a {
-		if a[idx].kind != b[idx].kind || !slices.Equal(a[idx].arches, b[idx].arches) {
+		if a[idx].Kind != b[idx].Kind || !slices.Equal(a[idx].Arches, b[idx].Arches) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-ups from the #1250 review:

- **Unified planner**: `pkg/dyld` now exports `DscExtractionPlan` and the remote path in `internal/commands/extract` uses it, replacing the near-verbatim duplicate helpers (`remoteDscExtractionSteps`, `remoteDscArchUsesRosetta`, `remoteX86DscRequiresRosetta`). DMG-path resolution stays per-callsite since local and remote want different fallbacks/error messages.
- **Dead code removed**: both planners carried an unreachable SystemOS fallback after the missing-RosettaOS error (`requiresRosetta` was invariantly true past the first early return).
- **Behavior change**: default `ipsw extract --dyld` (no `--dyld-arch`) on macOS 27+ now extracts from both SystemOS *and* RosettaOS DMGs. Previously it silently produced no x86_64 caches on 27+, where pre-27 IPSWs included them. When a 27+ BuildManifest lacks `Cryptex1,RosettaOS`, it extracts SystemOS only and logs a warning instead of erroring.

## Testing

`go build ./...`, `go vet`, and `go test ./pkg/dyld ./internal/commands/extract` pass. Planner tests updated: default-arches now expects both DMGs, plus a new case for 27+ with no RosettaOS cryptex; remote routing tests rewritten against the exported planner.

## AI Assistance

Written with Claude Code.