### PR TITLE
fix: correct occured->occurred + begining->beginning typos in error messages

### DIFF
--- a/cmd/ipsw/cmd/frida/frida_objc.go
+++ b/cmd/ipsw/cmd/frida/frida_objc.go
@@ -254,7 +254,7 @@ var fridaObjcCmd = &cobra.Command{
 				log.Info("Compiling bundle...")
 				script, err = session.CreateScript(bundle)
 				if err != nil {
-					log.Errorf("error ocurred creating script: %v", err)
+					log.Errorf("error occurred creating script: %v", err)
 					return
 				}
 
@@ -273,7 +273,7 @@ var fridaObjcCmd = &cobra.Command{
 		} else {
 			script, err = session.CreateScript(string(objcScriptData))
 			if err != nil {
-				return fmt.Errorf("error ocurred creating script: %v", err)
+				return fmt.Errorf("error occurred creating script: %v", err)
 			}
 
 			script.On("message", onMessage)

--- a/pkg/kernelcache/syscall.go
+++ b/pkg/kernelcache/syscall.go
@@ -363,7 +363,7 @@ func GetSyscallTable(m *macho.File) (uint64, []Sysent, error) {
 				})
 			}
 		} else {
-			return tableAddr, nil, fmt.Errorf("failed to find begining of syscalls sysent data")
+			return tableAddr, nil, fmt.Errorf("failed to find beginning of syscalls sysent data")
 		}
 	} else {
 		return tableAddr, nil, fmt.Errorf("failed to find __DATA_CONST __const section in kernel")

--- a/pkg/ota/aa.go
+++ b/pkg/ota/aa.go
@@ -94,7 +94,7 @@ type Config struct {
 func getKeyFromName(name string) (string, error) {
 	_, rest, ok := strings.Cut(name, "[")
 	if !ok {
-		return "", fmt.Errorf("begining of KEY '[' not found in '%s'", name)
+		return "", fmt.Errorf("beginning of KEY '[' not found in '%s'", name)
 	}
 	key, _, ok := strings.Cut(rest, "]")
 	if !ok {


### PR DESCRIPTION
## Summary
Two typo fixes in error messages:

1. **occured→occurred** (`pkg/ipsw/cmd/frida/frida_objc.go` lines 257, 276) — user-facing error messages
2. **begining→beginning** (`pkg/ota/aa.go` line 97, `pkg/kernelcache/syscall.go` line 366) — user-facing error messages

## Files changed
- `pkg/ipsw/cmd/frida/frida_objc.go` — 2 instances
- `pkg/ota/aa.go` — 1 instance  
- `pkg/kernelcache/syscall.go` — 1 instance

Total: 4 typo fixes, 3 files, 1 commit ✅