### PR TITLE
ci: run PCC watcher daily

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -77,23 +77,16 @@ jobs:
         # --mastodon-client-id ${{ secrets.MASTODON_CLIENT_ID }} \
         # --mastodon-client-secret ${{ secrets.MASTODON_CLIENT_SECRET }} \
         # --mastodon-access-token ${{ secrets.MASTODON_ACCESS_TOKEN }}
-      - name: Run ipsw watch PCC vphone600 firmware
-        run: |
-          go run ./cmd/ipsw/main.go watch pcc \
-          --interval 0 \
-          --state hack/.pcc_watch_state \
-          --discord \
-          --discord-id ${{ secrets.DISCORD_ID }} \
-          --discord-token ${{ secrets.DISCORD_TOKEN }}
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v5
         with:
-          commit_message: Update watch state
+          commit_message: Update .watch_cache
+          file_pattern: hack/.watch_cache
       # - name: Commit Cache Changes
       #   run:
       #     if [[ -n $(git status --porcelain) ]]; then
       #       git config --global user.email "github-actions[bot]@users.noreply.github.com"
       #       git config --global user.name "github-actions[bot]"
-      #       git add hack/.watch_cache hack/.pcc_watch_state
-      #       git commit -m "Update watch state"
+      #       git add hack/.watch_cache
+      #       git commit -m "Update .watch_cache"
       #       git push
       #     fi

--- a/.github/workflows/pcc-watch.yml
+++ b/.github/workflows/pcc-watch.yml
@@ -1,0 +1,34 @@
+name: "PCC Watch"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * *" # daily at 03:17 UTC
+
+permissions:
+  contents: write
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+      - name: Run ipsw watch PCC vphone600 firmware
+        run: |
+          go run ./cmd/ipsw/main.go watch pcc \
+          --interval 0 \
+          --state hack/.pcc_watch_state \
+          --discord \
+          --discord-id ${{ secrets.DISCORD_ID }} \
+          --discord-token ${{ secrets.DISCORD_TOKEN }}
+      - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v5
+        with:
+          commit_message: Update PCC watch state
+          file_pattern: hack/.pcc_watch_state


### PR DESCRIPTION
## Summary

- split the PCC vphone watcher from the 30-minute Discord workflow
- run PCC once daily at 03:17 UTC with manual dispatch retained
- scope each auto-commit action to its own state file

## Why

The shared workflow created 26 Update watch state commits in under 41 hours because the PCC transparency-log cursor advanced on nearly every run. The PCC watcher catches up from its durable cursor, so daily execution preserves release coverage while reducing state-only commits to at most one per day.

## Validation

- actionlint .github/workflows/discord.yml .github/workflows/pcc-watch.yml
- git diff --check
- go test -count=1 ./internal/commands/watch ./cmd/ipsw/cmd