### PR TITLE
feat(ai): add OrcaRouter as a --dec-llm provider

### DIFF
--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -18,6 +18,7 @@ import (
 	"github.com/blacktop/ipsw/internal/ai/ollama"
 	"github.com/blacktop/ipsw/internal/ai/openai"
 	"github.com/blacktop/ipsw/internal/ai/openrouter"
+	"github.com/blacktop/ipsw/internal/ai/orcarouter"
 	db "github.com/blacktop/ipsw/internal/db/ai"
 	model "github.com/blacktop/ipsw/internal/model/ai"
 	"gorm.io/gorm"
@@ -33,6 +34,7 @@ var Providers = []string{
 	"ollama",
 	"openai",
 	"openrouter",
+	"orcarouter",
 }
 
 var ProviderAliases = map[string]string{
@@ -350,6 +352,14 @@ func NewAI(ctx context.Context, cfg *Config) (AI, error) {
 		})
 	case "openrouter":
 		baseAI, err = openrouter.NewOpenRouter(ctx, &openrouter.Config{
+			Prompt:      cfg.Prompt,
+			Model:       cfg.Model,
+			Temperature: cfg.Temperature,
+			TopP:        cfg.TopP,
+			Stream:      cfg.Stream,
+		})
+	case "orcarouter":
+		baseAI, err = orcarouter.NewOrcaRouter(ctx, &orcarouter.Config{
 			Prompt:      cfg.Prompt,
 			Model:       cfg.Model,
 			Temperature: cfg.Temperature,

--- a/internal/ai/ai_test.go
+++ b/internal/ai/ai_test.go
@@ -7,3 +7,9 @@ func TestCopilotProviderAvailable(t *testing.T) {
 		t.Fatal("copilot must be exposed as a supported provider")
 	}
 }
+
+func TestOrcaRouterProviderAvailable(t *testing.T) {
+	if !IsValidProvider("orcarouter") {
+		t.Fatal("orcarouter must be exposed as a supported provider")
+	}
+}

--- a/internal/ai/orcarouter/orcarouter.go
+++ b/internal/ai/orcarouter/orcarouter.go
@@ -1,0 +1,254 @@
+package orcarouter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/blacktop/ipsw/internal/ai/utils"
+)
+
+const (
+	orcarouterChatCompletionsEndpoint = "https://api.orcarouter.ai/v1/chat/completions"
+	orcarouterModelsEndpoint          = "https://api.orcarouter.ai/v1/models"
+)
+
+// Config holds the configuration for the OrcaRouter LLM API client
+type Config struct {
+	Prompt      string  `json:"prompt"`
+	Model       string  `json:"model"`
+	Temperature float64 `json:"temperature"`
+	TopP        float64 `json:"top_p"`
+	Stream      bool    `json:"stream"`
+}
+
+// OrcaRouter represents a client for the OrcaRouter API
+type OrcaRouter struct {
+	ctx    context.Context
+	conf   *Config
+	client *http.Client
+	models map[string]string
+	apiKey string
+}
+
+// chatMessage represents a single message in the conversation
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatRequest is the payload sent to the OrcaRouter chat API
+type chatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	Temperature float64       `json:"temperature"`
+	TopP        float64       `json:"top_p"`
+	Stream      bool          `json:"stream"`
+}
+
+// chatResponse represents the response from the OrcaRouter chat API
+type chatResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// modelsResponse represents the response from the OrcaRouter models API.
+// It follows the OpenAI-compatible shape: model IDs are the lookup keys.
+type modelsResponse struct {
+	Data []struct {
+		ID                     string   `json:"id"`
+		Object                 string   `json:"object"`
+		Created                int64    `json:"created"`
+		OwnedBy                string   `json:"owned_by"`
+		SupportedEndpointTypes []string `json:"supported_endpoint_types"`
+	} `json:"data"`
+}
+
+// NewOrcaRouter creates a new OrcaRouter API client
+func NewOrcaRouter(ctx context.Context, conf *Config) (*OrcaRouter, error) {
+	apiKey := os.Getenv("ORCAROUTER_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("failed to create OrcaRouter client: ORCAROUTER_API_KEY environment variable is not set")
+	}
+
+	client := &OrcaRouter{
+		ctx:    ctx,
+		conf:   conf,
+		client: &http.Client{Timeout: 300 * time.Second},
+		models: make(map[string]string),
+		apiKey: apiKey,
+	}
+
+	return client, nil
+}
+
+// Models returns the available models from OrcaRouter
+func (c *OrcaRouter) Models() (map[string]string, error) {
+	if len(c.models) > 0 {
+		return c.models, nil
+	}
+	modelsResponse, err := c.getModels()
+	if err != nil {
+		return nil, fmt.Errorf("orcarouter: failed to get models: %w", err)
+	}
+
+	// Populate the models map with the model IDs
+	for _, model := range modelsResponse.Data {
+		c.models[model.ID] = model.ID
+	}
+
+	return c.models, nil
+}
+
+// SetModel sets the model to use for the OrcaRouter client
+func (c *OrcaRouter) SetModel(model string) error {
+	if _, ok := c.models[model]; !ok {
+		return fmt.Errorf("model '%s' not found", model)
+	}
+	c.conf.Model = model
+	return nil
+}
+
+// SetModels sets the available models for the OrcaRouter client
+func (c *OrcaRouter) SetModels(models map[string]string) (map[string]string, error) {
+	c.models = models
+	return c.models, nil
+}
+
+// Verify checks that the current model configuration is valid
+func (c *OrcaRouter) Verify() error {
+	if c.conf.Model == "" {
+		return fmt.Errorf("no model specified")
+	}
+	if len(c.models) == 0 {
+		if _, err := c.Models(); err != nil {
+			return fmt.Errorf("failed to fetch models: %v", err)
+		}
+	}
+	modelID, ok := c.models[c.conf.Model]
+	if !ok {
+		// Model not found in cache, try refreshing the models list
+		c.models = make(map[string]string) // Clear cache to force refresh
+		if _, err := c.Models(); err != nil {
+			return fmt.Errorf("failed to fetch models: %v", err)
+		}
+		// Check again after refresh
+		modelID, ok = c.models[c.conf.Model]
+		if !ok {
+			return fmt.Errorf("model '%s' not found in available models", c.conf.Model)
+		}
+	}
+	if modelID == "" {
+		return fmt.Errorf("model '%s' has empty ID", c.conf.Model)
+	}
+	return nil
+}
+
+// getModels retrieves the available models from OrcaRouter API
+func (c *OrcaRouter) getModels() (*modelsResponse, error) {
+	req, err := http.NewRequestWithContext(c.ctx, "GET", orcarouterModelsEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	c.setRequestHeaders(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var response modelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// Chat sends a message to the OrcaRouter API and returns the response
+func (c *OrcaRouter) Chat() (string, error) {
+	// Verify model configuration before making API call
+	if err := c.Verify(); err != nil {
+		return "", fmt.Errorf("invalid model configuration: %w", err)
+	}
+
+	reqBody := chatRequest{
+		Model:       c.models[c.conf.Model],
+		Messages:    []chatMessage{{Role: "user", Content: c.conf.Prompt}},
+		Temperature: c.conf.Temperature,
+		TopP:        c.conf.TopP,
+		Stream:      false, // We don't support streaming yet
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(c.ctx, "POST", orcarouterChatCompletionsEndpoint, bytes.NewBuffer(data))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	c.setRequestHeaders(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var response chatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if len(response.Choices) == 0 {
+		return "", fmt.Errorf("no response choices returned")
+	}
+
+	return utils.Clean(response.Choices[0].Message.Content), nil
+}
+
+// Close implements the ai.AI interface
+func (c *OrcaRouter) Close() error {
+	return nil // No specific resources to close for OrcaRouter client
+}
+
+// setRequestHeaders sets the common headers for OrcaRouter API requests
+func (c *OrcaRouter) setRequestHeaders(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+}

--- a/www/docs/cli/ipsw/dyld/disass.md
+++ b/www/docs/cli/ipsw/dyld/disass.md
@@ -35,6 +35,8 @@ ipsw dyld disass <DSC> [flags]
 ❯ ipsw dsc disass DSC --vaddr 0x1b19d6940 --dec --dec-llm openai
 # Decompile a function using OpenRouter to access various models
 ❯ ipsw dsc disass DSC --vaddr 0x1b19d6940 --dec --dec-llm openrouter --dec-model "OpenAI: GPT-4o-mini"
+# Decompile a function using OrcaRouter (namespaced model ids)
+❯ ipsw dsc disass DSC --vaddr 0x1b19d6940 --dec --dec-llm orcarouter --dec-model "openai/gpt-5.5"
 ```
 
 ### Options

--- a/www/docs/guides/decompiler.md
+++ b/www/docs/guides/decompiler.md
@@ -11,7 +11,7 @@ The **ipsw AI decompiler** revolutionizes binary analysis by leveraging state-of
 
 ## Requirements
 
-There are currently 9 supported LLM providers. Select one explicitly with
+There are currently 10 supported LLM providers. Select one explicitly with
 `--dec-llm` whenever you use `--dec`.
 
 - OpenAI
@@ -23,6 +23,7 @@ There are currently 9 supported LLM providers. Select one explicitly with
 - Gemini (ACP)
 - Ollama (local LLMs)
 - OpenRouter (API access to multiple models)
+- OrcaRouter (API access to multiple models)
 
 ## 🚀 Quick Start
 
@@ -138,6 +139,20 @@ export OPENROUTER_CLIENT_TITLE="ipsw-decompiler"  # Optional: for usage tracking
 # 3. Use with ipsw
 ipsw macho disass binary --dec --dec-llm openrouter
 ```
+
+### OrcaRouter (Multi-Provider Access)
+
+```bash
+# 1. Get API key from https://www.orcarouter.ai/console
+# 2. Set environment variables
+export ORCAROUTER_API_KEY="sk-orca-your-key-here"
+
+# 3. Use with ipsw
+ipsw macho disass binary --dec --dec-llm orcarouter
+```
+
+OrcaRouter uses namespaced model ids (e.g. `openai/gpt-5.5`, `anthropic/claude-sonnet-4.6`),
+so pass the full id with `--dec-model` when you want a specific model.
 
 ## 📖 Usage Examples
 

--- a/www/docs/roadmap.md
+++ b/www/docs/roadmap.md
@@ -7,7 +7,7 @@
 ## ✅ Major Milestones Achieved
 
 ### 🔥 Recent Breakthroughs (2024-2025)
-- [x] **AI-Powered Decompiler** - Integration with OpenAI, Claude, Gemini, Ollama, OpenRouter, and ACP agents including GitHub Copilot
+- [x] **AI-Powered Decompiler** - Integration with OpenAI, Claude, Gemini, Ollama, OpenRouter, OrcaRouter, and ACP agents including GitHub Copilot
 - [x] **Comprehensive Device Support** - Full iPhone, iPad, Apple Watch, Vision Pro, and Apple TV support
 - [x] **App Store Connect Integration** - Complete API for certificates, devices, and app management
 - [x] **Modern iOS Compatibility** - Support for latest iOS versions and features


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named `--dec-llm` provider alongside the existing OpenRouter entry. OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `internal/ai/orcarouter/orcarouter.go`: new provider client mirroring the OpenRouter implementation (base URL `https://api.orcarouter.ai/v1`, auth via `ORCAROUTER_API_KEY`). OrcaRouter's `/v1/models` response is OpenAI-shaped, so the model map is keyed by model id rather than display name.
- `internal/ai/ai.go`: registers `orcarouter` in the `Providers` list and wires `NewAI` to the new client, so `--dec-llm orcarouter` works and CLI completion lists it automatically.
- `internal/ai/ai_test.go`: asserts `orcarouter` is a valid provider, mirroring the existing copilot test.
- `www/docs/guides/decompiler.md`: adds OrcaRouter to the supported-provider list and a provider setup section.
- `www/docs/cli/ipsw/dyld/disass.md`: adds an OrcaRouter usage example.

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how OpenRouter is wired in this repo, so the `--dec-llm` picker, model list and docs stay consistent for users who want the multi-provider gateway behavior.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. Use the namespaced model id (e.g. `openai/gpt-5.5`, `anthropic/claude-sonnet-4.6`):

```bash
ipsw macho disass binary --dec --dec-llm orcarouter --dec-model "openai/gpt-5.5"
```

## Verification

- `go build ./internal/ai/...`, `go vet ./internal/ai/...`, and `go test ./internal/ai/` all pass.
- Live connectivity against `https://api.orcarouter.ai/v1` with an `sk-orca-` key:
  - `GET /v1/models` → 200, 192 models keyed by id (drives the `--dec-llm orcarouter` model picker).
  - `POST /v1/chat/completions` with `model="openai/gpt-5.5"` → 200.
  - Negative control: an embedding model id on the chat endpoint → 403, which is why the picker uses the `/models` list.
