### PR TITLE
fix(ota): find DSC arches across cryptexes

### DIFF
--- a/cmd/ipsw/cmd/ota/ota_extract_dyld_test.go
+++ b/cmd/ipsw/cmd/ota/ota_extract_dyld_test.go
@@ -108,6 +108,30 @@ func TestExtractDSCCryptexSuccessStopsThere(t *testing.T) {
 	}
 }
 
+func TestExtractDSCRequestedArchCanComeFromDifferentlyNamedCryptex(t *testing.T) {
+	src := &fakeDSCSource{cryptexFiles: []ota.ExtractedFile{{
+		Path:   "out/24G720__MacOS/System/Library/dyld/dyld_shared_cache_x86_64",
+		Source: "cryptex-system-arm64e",
+	}}}
+	opts := testOpts()
+	opts.Arches = []string{"x86_64"}
+
+	rep := extractDSC(src, opts)
+
+	if !rep.Complete {
+		t.Fatalf("report.Complete = false, errors = %+v", rep.Errors)
+	}
+	if len(rep.Files) != 1 {
+		t.Fatalf("report.Files = %+v, want one x86_64 entry", rep.Files)
+	}
+	if got := rep.Files[0]; got.Arch != "x86_64" || got.Source != "cryptex-system-arm64e" {
+		t.Fatalf("report file = {arch:%q source:%q}, want {x86_64 cryptex-system-arm64e}", got.Arch, got.Source)
+	}
+	if src.payloadCalls != 0 || len(src.copied) != 0 {
+		t.Fatalf("later sources ran after x86_64 was covered: asset=%v payload=%d", src.copied, src.payloadCalls)
+	}
+}
+
 func TestExtractDSCRequestedArchesFallThroughUntilCovered(t *testing.T) {
 	src := &fakeDSCSource{
 		cryptexFiles: []ota.ExtractedFile{{
@@ -144,6 +168,33 @@ func TestExtractDSCRequestedArchesFallThroughUntilCovered(t *testing.T) {
 	}
 	if len(src.cryptexArches) != 1 || strings.Join(src.cryptexArches[0], ",") != "arm64e,x86_64" {
 		t.Errorf("cryptex architecture filter = %v, want [arm64e x86_64]", src.cryptexArches)
+	}
+}
+
+func TestExtractDSCAbsentRequestedArchHasStructuralDiscoveryOutcome(t *testing.T) {
+	src := &fakeDSCSource{}
+	opts := testOpts()
+	opts.Arches = []string{"x86_64"}
+
+	rep := extractDSC(src, opts)
+
+	if rep.Complete {
+		t.Fatal("report.Complete = true with x86_64 absent")
+	}
+	if len(rep.Files) != 0 {
+		t.Fatalf("report.Files = %+v, want none", rep.Files)
+	}
+	if len(rep.Errors) != 1 {
+		t.Fatalf("report.Errors = %+v, want one absence entry", rep.Errors)
+	}
+	if got := rep.Errors[0]; got.Phase != ota.PhaseDSCDiscovery || got.Source != "" {
+		t.Fatalf("absence error = {phase:%q source:%q}, want {dsc-discovery <empty>}", got.Phase, got.Source)
+	}
+	if rep.fatalErr() == nil {
+		t.Fatal("fatalErr() = nil for an explicitly requested architecture")
+	}
+	if src.payloadCalls != 1 {
+		t.Fatalf("payload source ran %d time(s), want exhaustive final fallback", src.payloadCalls)
 	}
 }
 

--- a/pkg/ota/aa.go
+++ b/pkg/ota/aa.go
@@ -738,10 +738,10 @@ func (r *Reader) ExtractFromCryptexesWithSources(pattern, output string) (files 
 	return r.ExtractFromCryptexesWithSourcesForArches(pattern, output, nil)
 }
 
-// ExtractFromCryptexesWithSourcesForArches is the architecture-filtered form
-// of [Reader.ExtractFromCryptexesWithSources]. It skips cryptex members that
-// cannot carry any requested cache family before staging or mounting them.
-// An empty arches slice preserves the all-cryptex behavior.
+// ExtractFromCryptexesWithSourcesForArches limits extraction to requested
+// architectures. It checks system cryptexes in order because their filenames
+// do not always describe every cache inside, and stops once every requested
+// cache family is found. An empty arches slice checks every system cryptex.
 func (r *Reader) ExtractFromCryptexesWithSourcesForArches(pattern, output string, arches []string) (files []ExtractedFile, err error) {
 	match, err := regexp.Compile(pattern)
 	if err != nil {
@@ -773,9 +773,13 @@ func extractFromDscCryptexFiles(files []*File, extract func(*File) ([]string, er
 func extractFromDscCryptexFilesForArches(files []*File, arches []string, extract func(*File) ([]string, error)) ([]ExtractedFile, error) {
 	var out []ExtractedFile
 	var extractErrs []error
+	missing := make(map[string]struct{}, len(arches))
+	for _, arch := range arches {
+		missing[arch] = struct{}{}
+	}
 
 	for _, file := range files {
-		if !reOTADscCryptex.MatchString(file.Base()) || !cryptexMatchesArches(file.Base(), arches) {
+		if !reOTADscCryptex.MatchString(file.Base()) {
 			continue
 		}
 		extracted, err := extract(file)
@@ -784,37 +788,32 @@ func extractFromDscCryptexFilesForArches(files []*File, arches []string, extract
 		}
 		if err != nil {
 			extractErrs = append(extractErrs, wrapPhase(PhaseCryptexDiscovery, file.Base(), err))
+		} else {
+			for _, path := range extracted {
+				for arch := range missing {
+					if dscPathMatchesArch(path, arch) {
+						delete(missing, arch)
+					}
+				}
+			}
+		}
+		if len(arches) > 0 && len(missing) == 0 {
+			break
 		}
 	}
 
 	return out, errors.Join(extractErrs...)
 }
 
-// cryptexMatchesArches reports whether a cryptex member can carry at least one
-// requested cache family. Rosetta cryptexes can carry x86_64, x86_64h and AOT
-// caches; older OTAs can name the x86 cryptex directly.
-func cryptexMatchesArches(source string, arches []string) bool {
-	if len(arches) == 0 {
-		return true
+// dscPathMatchesArch uses the materialized cache basename, which identifies
+// cache contents authoritatively. The enclosing cryptex basename does not.
+func dscPathMatchesArch(path, arch string) bool {
+	base := filepath.Base(path)
+	if arch == "aot" {
+		return strings.HasPrefix(base, "aot_shared_cache.")
 	}
-	sourceArch := strings.TrimPrefix(source, "cryptex-system-")
-	for _, arch := range arches {
-		switch arch {
-		case "aot":
-			if sourceArch == "rosetta" || sourceArch == "x86_64" || sourceArch == "x86_64h" {
-				return true
-			}
-		case "x86_64", "x86_64h":
-			if sourceArch == arch || sourceArch == "rosetta" {
-				return true
-			}
-		default:
-			if sourceArch == arch {
-				return true
-			}
-		}
-	}
-	return false
+	prefix := "dyld_shared_cache_" + arch
+	return base == prefix || strings.HasPrefix(base, prefix+".")
 }
 
 func (r *Reader) extractFromCryptexFile(file *File, match *regexp.Regexp, tmpdir, output string) (out []string, err error) {

--- a/pkg/ota/aa_test.go
+++ b/pkg/ota/aa_test.go
@@ -159,48 +159,112 @@ func TestExtractFromDscCryptexFilesReturnsNilErrorWhenAllCryptexesSucceed(t *tes
 	}
 }
 
-func TestExtractFromDscCryptexFilesFiltersArchesBeforeExtraction(t *testing.T) {
+func TestExtractFromDscCryptexFilesForArchesSearchesContentsInsteadOfBasenames(t *testing.T) {
 	files := []*File{
-		{name: "AssetData/payloadv2/image_patches/cryptex-system-arm64"},
 		{name: "AssetData/payloadv2/image_patches/cryptex-system-arm64e"},
-		{name: "AssetData/payloadv2/image_patches/cryptex-system-arm64_32"},
-		{name: "AssetData/payloadv2/image_patches/cryptex-system-rosetta"},
+		{name: "AssetData/payloadv2/image_patches/cryptex-system-x86_64"},
 	}
 	var called []string
-	out, err := extractFromDscCryptexFilesForArches(files, []string{"arm64_32"}, func(file *File) ([]string, error) {
+	out, err := extractFromDscCryptexFilesForArches(files, []string{"x86_64"}, func(file *File) ([]string, error) {
 		called = append(called, file.Base())
-		return []string{"out/System/Library/dyld/dyld_shared_cache_arm64_32"}, nil
+		if file.Base() != "cryptex-system-arm64e" {
+			t.Fatalf("extraction continued with %q after x86_64 was already materialized", file.Base())
+		}
+		return []string{"out/System/Library/dyld/dyld_shared_cache_x86_64"}, nil
 	})
 	if err != nil {
 		t.Fatalf("extractFromDscCryptexFilesForArches() unexpected error: %v", err)
 	}
-	if want := []string{"cryptex-system-arm64_32"}; !slices.Equal(called, want) {
+	if want := []string{"cryptex-system-arm64e"}; !slices.Equal(called, want) {
 		t.Fatalf("extracted cryptexes = %v, want %v", called, want)
 	}
-	if len(out) != 1 || out[0].Source != "cryptex-system-arm64_32" {
-		t.Fatalf("output = %+v, want one arm64_32-sourced file", out)
+	want := []ExtractedFile{{
+		Path:   "out/System/Library/dyld/dyld_shared_cache_x86_64",
+		Source: "cryptex-system-arm64e",
+	}}
+	if !slices.Equal(out, want) {
+		t.Fatalf("output = %+v, want %+v", out, want)
 	}
 }
 
-func TestCryptexMatchesArches(t *testing.T) {
+func TestExtractFromDscCryptexFilesForArchesDoesNotStopOnPartialFailure(t *testing.T) {
+	files := []*File{
+		{name: "AssetData/payloadv2/image_patches/cryptex-system-arm64e"},
+		{name: "AssetData/payloadv2/image_patches/cryptex-system-x86_64"},
+	}
+	var called []string
+	out, err := extractFromDscCryptexFilesForArches(files, []string{"x86_64"}, func(file *File) ([]string, error) {
+		called = append(called, file.Base())
+		path := "out/System/Library/dyld/dyld_shared_cache_x86_64"
+		if file.Base() == "cryptex-system-arm64e" {
+			return []string{path}, errors.New("copy failed after a partial result")
+		}
+		return []string{path}, nil
+	})
+	if err == nil {
+		t.Fatal("extractFromDscCryptexFilesForArches() error = nil, want the partial failure preserved")
+	}
+	wantCalled := []string{"cryptex-system-arm64e", "cryptex-system-x86_64"}
+	if !slices.Equal(called, wantCalled) {
+		t.Fatalf("extracted cryptexes = %v, want %v", called, wantCalled)
+	}
+	if len(out) != 2 {
+		t.Fatalf("output = %+v, want both partial and later successful results", out)
+	}
+}
+
+func TestExtractFromDscCryptexFilesForArchesSearchesEveryCandidateWhenAbsent(t *testing.T) {
+	files := []*File{
+		{name: "AssetData/payloadv2/image_patches/cryptex-system-arm64"},
+		{name: "AssetData/payloadv2/image_patches/cryptex-system-arm64e"},
+		{name: "AssetData/payloadv2/image_patches/cryptex-system-arm64_32"},
+		{name: "AssetData/payloadv2/image_patches/cryptex-system-x86_64"},
+		{name: "AssetData/payloadv2/image_patches/cryptex-system-x86_64h"},
+		{name: "AssetData/payloadv2/image_patches/cryptex-system-rosetta"},
+		{name: "AssetData/payloadv2/image_patches/cryptex-app"},
+	}
+	var called []string
+	out, err := extractFromDscCryptexFilesForArches(files, []string{"x86_64"}, func(file *File) ([]string, error) {
+		called = append(called, file.Base())
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("extractFromDscCryptexFilesForArches() unexpected error: %v", err)
+	}
+	want := []string{
+		"cryptex-system-arm64",
+		"cryptex-system-arm64e",
+		"cryptex-system-arm64_32",
+		"cryptex-system-x86_64",
+		"cryptex-system-x86_64h",
+		"cryptex-system-rosetta",
+	}
+	if !slices.Equal(called, want) {
+		t.Fatalf("extracted cryptexes = %v, want exhaustive search of %v", called, want)
+	}
+	if out != nil {
+		t.Fatalf("output = %+v, want nil", out)
+	}
+}
+
+func TestDscPathMatchesArch(t *testing.T) {
 	tests := []struct {
-		name   string
-		source string
-		arches []string
-		want   bool
+		name string
+		path string
+		arch string
+		want bool
 	}{
-		{name: "empty selects all", source: "cryptex-system-arm64e", want: true},
-		{name: "native exact", source: "cryptex-system-arm64e", arches: []string{"arm64e"}, want: true},
-		{name: "native mismatch", source: "cryptex-system-arm64", arches: []string{"arm64e"}},
-		{name: "arm64_32 exact", source: "cryptex-system-arm64_32", arches: []string{"arm64_32"}, want: true},
-		{name: "rosetta carries x86", source: "cryptex-system-rosetta", arches: []string{"x86_64"}, want: true},
-		{name: "rosetta carries aot", source: "cryptex-system-rosetta", arches: []string{"aot"}, want: true},
-		{name: "older x86 cryptex can carry aot", source: "cryptex-system-x86_64h", arches: []string{"aot"}, want: true},
+		{name: "primary", path: "out/System/Library/dyld/dyld_shared_cache_arm64", arch: "arm64", want: true},
+		{name: "subcache", path: "out/System/Library/dyld/dyld_shared_cache_x86_64.06", arch: "x86_64", want: true},
+		{name: "symbols", path: "out/System/Library/dyld/dyld_shared_cache_arm64e.symbols", arch: "arm64e", want: true},
+		{name: "architecture boundary", path: "out/System/Library/dyld/dyld_shared_cache_arm64e", arch: "arm64"},
+		{name: "aot", path: "out/System/Library/dyld/aot_shared_cache.0", arch: "aot", want: true},
+		{name: "not aot", path: "out/System/Library/dyld/dyld_shared_cache_x86_64", arch: "aot"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := cryptexMatchesArches(tt.source, tt.arches); got != tt.want {
-				t.Fatalf("cryptexMatchesArches(%q, %v) = %t, want %t", tt.source, tt.arches, got, tt.want)
+			if got := dscPathMatchesArch(tt.path, tt.arch); got != tt.want {
+				t.Fatalf("dscPathMatchesArch(%q, %q) = %t, want %t", tt.path, tt.arch, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This is a follow-up to my last issue; please let me know if this fits your approach to handling the cryptex situation in OTAs.

The architecture in a cryptex filename does not always describe every cache inside it. In [macOS `25G76`](https://updates.cdn-apple.com/2026SummerFCS/patches/140-84393/BCFA6EE4-8FB6-4ABD-B53F-51CF52B718D5/com_apple_MobileAsset_MacSoftwareUpdate/29dc838f43ae82dd46066069d5c21d83cd503b97.zip), the `x86_64` cache is stored inside `cryptex-system-arm64e`, so `x86_64`-only extraction currently fails.

This PR suggests checking system cryptex contents until it finds all requested architectures, then stopping before mounting unnecessary images. If extraction produces files but also encounters an error, keep the files in the report while still reporting the failure.

From the `symx` POV, we want to process one architecture at a time so large OTAs don't require disk space for every materialized cache at once. After each request, `symx` can split the cache, retain a smaller intermediate result, and remove the materialized files before requesting the next architecture. Without this fix, an `x86_64`-only request can incorrectly report that the cache is missing, preventing that sequential flow.

## Testing

- `go test ./pkg/ota ./cmd/ipsw/cmd/ota`
- `make build`
- Verified `25G76` extraction for `x86_64`, `arm64e`, and both combined
- Confirmed `x86_64` is reported from `cryptex-system-arm64e` and later cryptexes are not mounted

## AI Assistance

I used gpt-5.6 for much of the implementation and verification.
