### PR TITLE
fix: Invalid mount point

### DIFF
--- a/internal/utils/macos.go
+++ b/internal/utils/macos.go
@@ -700,10 +700,10 @@ func MountDMG(image string, customMountPoint string) (string, bool, error) {
 			}
 			return mountPoint, true, nil
 		}
-	} else {
-		if err := os.MkdirAll(mountPoint, 0750); err != nil {
-			return "", false, fmt.Errorf("failed to create temporary mount point %s: %v", mountPoint, err)
-		}
+	}
+
+	if err := os.MkdirAll(mountPoint, 0750); err != nil {
+		return "", false, fmt.Errorf("failed to create temporary mount point %s: %w", mountPoint, err)
 	}
 
 	if err := Mount(image, mountPoint); err != nil {


### PR DESCRIPTION
## Summary

diskutil requires the mount point to exist before attaching the image.

## Testing

./ipsw extract ../iPhone12,1_27.0_24A435_Restore.ipsw --dyld --output out

## AI Assistance

none